### PR TITLE
Add master action experiment mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import logging
 
 from highwayenv.utils import patch_intersection_env, register_intersection_env
 from src.experiment import scenarios_config as sc
-from src.experiment.experiment_config import Experiment
+from src.experiment.experiment_config import Experiment, MasterActionExperiment
 from src.training.training_handler import run_experiment
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -39,12 +39,20 @@ if __name__ == "__main__":
         EPOCHS=1,
         CYCLES=3)
 
+    master_action_experiment = MasterActionExperiment(
+        EXPERIMENT_ID='MasterActionExp',
+        LOAD_MODEL_DIRECTORY='experiments/08_12_2024-13_56_13_Experiment1/trained_model.zip',
+        EPOCHS=1,
+        CYCLES=3,
+    )
+
     # dictionary were the keys are EXPERIMENT_ID (experiment name) and the values are environment configurations defined in scenarios_config.py
     custom_env_configs = {
-        experiment5_config.EXPERIMENT_ID: sc.full_env_config_exp5
+        experiment5_config.EXPERIMENT_ID: sc.full_env_config_exp5,
+        master_action_experiment.EXPERIMENT_ID: sc.full_env_config_exp5,
     }
 
-    experiments = [experiment5_config]  # , experiment1]
+    experiments = [experiment5_config, master_action_experiment]
     for experiment_config in experiments:
         print(f"Starting experiment: {experiment_config.EXPERIMENT_ID}")
         run_experiment(experiment_config, custom_env_configs[experiment_config.EXPERIMENT_ID])

--- a/src/experiment/experiment_config.py
+++ b/src/experiment/experiment_config.py
@@ -37,8 +37,12 @@ class Experiment:
     LONGITUDINAL: int = 40
     LATERAL: int = 0
 
-    # Master embedding size configuration
+    # Master output configuration
     EMBEDDING_SIZE: int = 4
+    MASTER_OUTPUT_MODE: str = "embedding"  # "embedding" or "actions"
+    MASTER_ACTION_DIM: int = 2
+    MASTER_ACTION_THRESHOLD: float = 0.0
+    USE_MASTER_ACTIONS: bool = False
 
     # Cars Setup Configuration
     RANDOM_INIT: bool = False
@@ -50,7 +54,7 @@ class Experiment:
 
     # State Configuration - still 8-dimensional (4 from car state + 4 from master embedding)
     AGENT_STATE_SIZE: int = 4
-    STATE_INPUT_SIZE: int = EMBEDDING_SIZE + AGENT_STATE_SIZE  # 8
+    STATE_INPUT_SIZE: int = EMBEDDING_SIZE + AGENT_STATE_SIZE  # 8 (will be adjusted in __post_init__)
 
     # Action Configurationss
     ACTION_SPACE_SIZE: int = 2
@@ -98,6 +102,13 @@ class Experiment:
     SCALING: float = 3 * 1.3
 
     def __post_init__(self):
+        # Dynamically adjust observation size based on master output mode
+        if getattr(self, "MASTER_OUTPUT_MODE", "embedding") == "actions":
+            action_dim = getattr(self, "MASTER_ACTION_DIM", self.EMBEDDING_SIZE)
+            self.STATE_INPUT_SIZE = self.AGENT_STATE_SIZE + action_dim
+        else:
+            self.STATE_INPUT_SIZE = self.AGENT_STATE_SIZE + self.EMBEDDING_SIZE
+
         self.EXPERIMENT_PATH = f"experiments/{self.EXPERIMENT_DATE_TIME}_{self.EXPERIMENT_ID}"
         self.SAVE_MODEL_DIRECTORY = f"{self.EXPERIMENT_PATH}/trained_model"
 
@@ -116,3 +127,16 @@ class Experiment:
         #     run_name=self.EXPERIMENT_ID,
         #     tags=["experiment", "training"]
         # )
+
+
+@dataclass
+class MasterActionExperiment(Experiment):
+    """Experiment configuration where the master outputs acceleration decisions."""
+
+    MASTER_OUTPUT_MODE: str = "actions"
+    USE_MASTER_ACTIONS: bool = True
+    MASTER_ACTION_DIM: int = 2
+    MASTER_ACTION_THRESHOLD: float = 0.0
+
+    def __post_init__(self):
+        super().__post_init__()

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -50,6 +50,10 @@ class Driver(gym.Env):
         self.current_state = None
         self.current_embedding = None
         self.current_master_actions = np.zeros(self.master_action_dim, dtype=np.float32)
+        self.last_master_output = None
+        self.last_master_value = None
+        self.last_master_log_prob = None
+        self.last_applied_action_tuple = tuple()
 
         # Create the underlying Highway environment
         self.highway_env = gym.make('RELintersection-v0', render_mode="rgb_array", config=self.config)
@@ -124,16 +128,8 @@ class Driver(gym.Env):
         current_state = self._prepare_state_for_master(current_state)
 
         if self.master_model is not None:
-            master_input = torch.tensor(current_state.reshape(1, -1), dtype=torch.float32)
-            master_output, _, _ = self.master_model.get_proto_action(master_input)
-            if self.use_master_actions:
-                self.current_master_actions = self.convert_master_output_to_actions(
-                    master_output,
-                    self.master_action_dim,
-                    self.master_action_threshold,
-                ).astype(np.float32)
-            else:
-                self.current_embedding = master_output
+            self._update_master_outputs(current_state)
+            self.last_applied_action_tuple = tuple()
         else:
             raise ValueError("master not available")
 
@@ -166,20 +162,18 @@ class Driver(gym.Env):
         """Execute action and return observations for both agents."""
         self.episode_step += 1
 
-        next_state, reward, done, truncated, info = self.highway_env.step(action_tuple)
+        if self.use_master_actions:
+            master_action_tuple = self._build_master_action_tuple()
+            self.last_applied_action_tuple = master_action_tuple
+            for idx, action in enumerate(master_action_tuple, start=1):
+                print(f"[MasterAction] Step {self.episode_step}: Car {idx} -> {action}")
+            next_state, reward, done, truncated, info = self.highway_env.step(master_action_tuple)
+        else:
+            next_state, reward, done, truncated, info = self.highway_env.step(action_tuple)
         next_state = self._prepare_state_for_master(next_state)
 
         if self.master_model is not None:
-            master_input = torch.tensor(next_state.reshape(1, -1), dtype=torch.float32)
-            master_output, _, _ = self.master_model.get_proto_action(master_input)
-            if self.use_master_actions:
-                self.current_master_actions = self.convert_master_output_to_actions(
-                    master_output,
-                    self.master_action_dim,
-                    self.master_action_threshold,
-                ).astype(np.float32)
-            else:
-                self.current_embedding = master_output
+            self._update_master_outputs(next_state)
         else:
             print('master is none')
             if self.use_master_actions:
@@ -215,6 +209,43 @@ class Driver(gym.Env):
 
         # Return same format as reset() - both observations
         return agent_observation_car1, agent_observation_car2, reward, done, truncated, info
+
+    def _update_master_outputs(self, state):
+        flat_state = np.array(state, dtype=np.float32).reshape(1, -1)
+        master_input = torch.tensor(flat_state, dtype=torch.float32)
+        master_output, value, log_prob = self.master_model.get_proto_action(master_input)
+        self.last_master_output = master_output
+        self.last_master_value = value
+        self.last_master_log_prob = log_prob
+        if self.use_master_actions:
+            self.current_master_actions = self.convert_master_output_to_actions(
+                master_output,
+                self.master_action_dim,
+                self.master_action_threshold,
+            ).astype(np.float32)
+        else:
+            self.current_embedding = master_output
+
+    def _build_master_action_tuple(self):
+        env = self._get_unwrapped_env()
+        num_cars = 0
+        if hasattr(env, 'controlled_vehicles'):
+            num_cars = len(env.controlled_vehicles)
+        if num_cars == 0:
+            num_cars = len(self.current_master_actions)
+        actions = []
+        for idx in range(num_cars):
+            if idx < len(self.current_master_actions):
+                actions.append(int(self.current_master_actions[idx]))
+            else:
+                actions.append(0)
+        return tuple(actions)
+
+    def get_current_master_action_tuple(self):
+        if not self.use_master_actions:
+            raise RuntimeError("Master actions are not enabled in this experiment")
+        return self._build_master_action_tuple()
+
     def render(self, mode='human'):
         """
         Render the environment.

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -21,6 +21,10 @@ class Driver(gym.Env):
         super().__init__()
         self.experiment = experiment
         self.master_model = master_model
+        self.master_output_mode = getattr(experiment, "MASTER_OUTPUT_MODE", "embedding")
+        self.use_master_actions = getattr(experiment, "USE_MASTER_ACTIONS", False)
+        self.master_action_threshold = getattr(experiment, "MASTER_ACTION_THRESHOLD", 0.0)
+        self.master_action_dim = getattr(experiment, "MASTER_ACTION_DIM", 2)
 
         # Load environment configuration
         self.config = experiment.CONFIG if hasattr(experiment, 'CONFIG') else None
@@ -45,6 +49,7 @@ class Driver(gym.Env):
         # Environment state
         self.current_state = None
         self.current_embedding = None
+        self.current_master_actions = np.zeros(self.master_action_dim, dtype=np.float32)
 
         # Create the underlying Highway environment
         self.highway_env = gym.make('RELintersection-v0', render_mode="rgb_array", config=self.config)
@@ -120,8 +125,15 @@ class Driver(gym.Env):
 
         if self.master_model is not None:
             master_input = torch.tensor(current_state.reshape(1, -1), dtype=torch.float32)
-            embedding, _, _ = self.master_model.get_proto_action(master_input)
-            self.current_embedding = embedding
+            master_output, _, _ = self.master_model.get_proto_action(master_input)
+            if self.use_master_actions:
+                self.current_master_actions = self.convert_master_output_to_actions(
+                    master_output,
+                    self.master_action_dim,
+                    self.master_action_threshold,
+                ).astype(np.float32)
+            else:
+                self.current_embedding = master_output
         else:
             raise ValueError("master not available")
 
@@ -141,8 +153,12 @@ class Driver(gym.Env):
         else:
             car2_state = current_state[4:8] if len(current_state.shape) == 1 else current_state[1]
 
-        agent_observation_car1 = np.concatenate((car1_state, self.current_embedding))
-        agent_observation_car2 = np.concatenate((car2_state, self.current_embedding))
+        if self.use_master_actions:
+            agent_observation_car1 = np.concatenate((car1_state, self.current_master_actions))
+            agent_observation_car2 = np.concatenate((car2_state, self.current_master_actions))
+        else:
+            agent_observation_car1 = np.concatenate((car1_state, self.current_embedding))
+            agent_observation_car2 = np.concatenate((car2_state, self.current_embedding))
 
         return agent_observation_car1, agent_observation_car2, info
 
@@ -155,11 +171,21 @@ class Driver(gym.Env):
 
         if self.master_model is not None:
             master_input = torch.tensor(next_state.reshape(1, -1), dtype=torch.float32)
-            embedding, _, _ = self.master_model.get_proto_action(master_input)
-            self.current_embedding = embedding
+            master_output, _, _ = self.master_model.get_proto_action(master_input)
+            if self.use_master_actions:
+                self.current_master_actions = self.convert_master_output_to_actions(
+                    master_output,
+                    self.master_action_dim,
+                    self.master_action_threshold,
+                ).astype(np.float32)
+            else:
+                self.current_embedding = master_output
         else:
             print('master is none')
-            self.current_embedding = np.zeros(4)
+            if self.use_master_actions:
+                self.current_master_actions = np.zeros(self.master_action_dim, dtype=np.float32)
+            else:
+                self.current_embedding = np.zeros(4)
 
         env = self._get_unwrapped_env()
 
@@ -177,8 +203,12 @@ class Driver(gym.Env):
         else:
             car2_state = next_state[4:8] if len(next_state.shape) == 1 else next_state[1]
 
-        agent_observation_car1 = np.concatenate((car1_state, self.current_embedding))
-        agent_observation_car2 = np.concatenate((car2_state, self.current_embedding))
+        if self.use_master_actions:
+            agent_observation_car1 = np.concatenate((car1_state, self.current_master_actions))
+            agent_observation_car2 = np.concatenate((car2_state, self.current_master_actions))
+        else:
+            agent_observation_car1 = np.concatenate((car1_state, self.current_embedding))
+            agent_observation_car2 = np.concatenate((car2_state, self.current_embedding))
 
         self.current_state = next_state
         self.total_episode_reward += reward
@@ -204,6 +234,16 @@ class Driver(gym.Env):
         if hasattr(self.highway_env, 'seed'):
             return self.highway_env.seed(seed)
         return None
+
+    @staticmethod
+    def convert_master_output_to_actions(master_output, action_dim, threshold=0.0):
+        values = np.array(master_output).flatten()
+        if values.size < action_dim:
+            values = np.pad(values, (0, action_dim - values.size))
+        elif values.size > action_dim:
+            values = values[:action_dim]
+        discrete = (values >= threshold).astype(int)
+        return discrete
 
 
 class DummyVecEnv(gym.Wrapper):

--- a/src/model/master_action_model.py
+++ b/src/model/master_action_model.py
@@ -1,0 +1,133 @@
+import os
+from typing import Tuple
+
+import gymnasium as gym
+import numpy as np
+import torch
+from gymnasium import spaces
+from stable_baselines3 import PPO
+from stable_baselines3.common.buffers import RolloutBuffer
+
+from src.model.master_model import SimpleResNetExtractor
+
+
+class ActionMasterModel:
+    """Master network that outputs acceleration/deceleration decisions."""
+
+    def __init__(self, action_dim=2, experiment=None, observation_dim=None, **kwargs):
+        self.action_dim = action_dim
+        self.experiment = experiment
+        self.is_frozen = False
+
+        if observation_dim is not None:
+            self.observation_dim = observation_dim
+        elif experiment is not None:
+            max_cars = getattr(experiment, "CARS_AMOUNT", 5)
+            self.observation_dim = max_cars * 4
+        else:
+            self.observation_dim = 20
+
+        dummy_env = gym.Env()
+        dummy_env.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(self.observation_dim,), dtype=np.float32
+        )
+        dummy_env.action_space = spaces.Box(
+            low=-1.0, high=1.0, shape=(self.action_dim,), dtype=np.float32
+        )
+
+        try:
+            n_steps = experiment.N_STEPS if experiment and hasattr(experiment, "N_STEPS") else 64
+        except Exception:
+            n_steps = 64
+
+        self.model = PPO(
+            "MlpPolicy",
+            dummy_env,
+            learning_rate=1e-2,
+            n_steps=n_steps,
+            batch_size=128,
+            gamma=0.99,
+            gae_lambda=0.95,
+            clip_range=0.9,
+            ent_coef=0.01,
+            vf_coef=0.5,
+            policy_kwargs=dict(
+                features_extractor_class=SimpleResNetExtractor,
+                features_extractor_kwargs=dict(features_dim=128),
+                net_arch=[64, 32],
+            ),
+            verbose=1,
+            device="cpu",
+        )
+
+        self.rollout_buffer = RolloutBuffer(
+            buffer_size=n_steps,
+            observation_space=dummy_env.observation_space,
+            action_space=dummy_env.action_space,
+            gamma=0.99,
+            gae_lambda=0.95,
+            n_envs=1,
+        )
+
+    def unfreeze(self):
+        self.is_frozen = False
+        for param in self.model.policy.parameters():
+            param.requires_grad = True
+        self.model.policy.set_training_mode(True)
+        print("[ActionMaster] UNFROZEN - Training enabled")
+
+    def freeze(self):
+        self.is_frozen = True
+        for param in self.model.policy.parameters():
+            param.requires_grad = False
+        self.model.policy.set_training_mode(False)
+        print("[ActionMaster] FROZEN - Training disabled")
+
+    def get_proto_action(self, state_tensor) -> Tuple[np.ndarray, torch.Tensor, torch.Tensor]:
+        if isinstance(state_tensor, np.ndarray) and state_tensor.shape == (5, 4):
+            obs = state_tensor.flatten()
+        else:
+            obs = np.array(state_tensor).flatten()
+
+        if len(obs) < self.observation_dim:
+            padded_obs = np.zeros(self.observation_dim)
+            padded_obs[: len(obs)] = obs
+            obs = padded_obs
+        elif len(obs) > self.observation_dim:
+            obs = obs[: self.observation_dim]
+
+        obs_tensor = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
+
+        with torch.no_grad():
+            action, value, log_prob = self.model.policy.forward(obs_tensor)
+            action_np = action.cpu().numpy()[0]
+            value_tensor = value.cpu()
+            log_prob_tensor = log_prob.cpu()
+
+        return action_np, value_tensor, log_prob_tensor
+
+    @staticmethod
+    def to_discrete_actions(action_values, threshold=0.0, action_dim=None):
+        arr = np.array(action_values).flatten()
+        if action_dim is not None and arr.size < action_dim:
+            arr = np.pad(arr, (0, action_dim - arr.size))
+        if action_dim is not None and arr.size > action_dim:
+            arr = arr[:action_dim]
+        discrete = (arr >= threshold).astype(int)
+        return discrete
+
+    def set_logger(self, logger):
+        self.model.set_logger(logger)
+
+    def save(self, path):
+        self.model.save(path)
+        custom_params = {
+            "action_dim": self.action_dim,
+        }
+        torch.save(custom_params, f"{path}_custom_params.pt")
+
+    def load(self, path):
+        self.model = PPO.load(path)
+        if os.path.exists(f"{path}_custom_params.pt"):
+            custom_params = torch.load(f"{path}_custom_params.pt")
+            self.action_dim = custom_params.get("action_dim", self.action_dim)

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -18,6 +18,7 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
     all_rewards, actions_per_episode = [], []
     steps_counter, episode_sum_of_rewards = 0, 0
     crashed = False
+    use_master_actions = getattr(experiment, 'USE_MASTER_ACTIONS', False)
 
     car1_observation, car2_observation, _ = env.reset()
     done, truncated = False, False
@@ -29,28 +30,44 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         all_drivers_states = env.env.current_state
 
         # Compute master embedding & (for later optionally use) its value/log_prob
-        embedding, value, log_prob = master_model.get_proto_action(ensure_tensor(all_drivers_states))
+        master_output, value, log_prob = master_model.get_proto_action(ensure_tensor(all_drivers_states))
 
-        # Choose agent action and compute its metrics
-        car1_action, car2_action = Driver.get_action(agent_model, car1_observation, car2_observation, total_steps,
-                                                     experiment.EXPLORATION_EXPLOITATION_THRESHOLD)
+        if use_master_actions:
+            action_dim = getattr(experiment, 'MASTER_ACTION_DIM', len(master_output))
+            threshold = getattr(experiment, 'MASTER_ACTION_THRESHOLD', 0.0)
+            master_actions = Driver.convert_master_output_to_actions(master_output, action_dim, threshold)
+            env_action = tuple(int(a) for a in master_actions)
+        else:
+            car1_action, car2_action = Driver.get_action(
+                agent_model,
+                car1_observation,
+                car2_observation,
+                total_steps,
+                experiment.EXPLORATION_EXPLOITATION_THRESHOLD,
+            )
 
-        car1_scalar_action, car1_action_array = get_scaler_action_and_action_array(car1_action)
-        car2_scalar_action, car2_action_array = get_scaler_action_and_action_array(car2_action)
+            car1_scalar_action, car1_action_array = get_scaler_action_and_action_array(car1_action)
+            car2_scalar_action, car2_action_array = get_scaler_action_and_action_array(car2_action)
 
-        #print(f"Actions: [{car1_scalar_action}, {car2_scalar_action}]")
+            if train_both or not training_master:
+                car1_values, car1_log_prob = get_agent_values_from_observation(
+                    car1_observation, car1_action_array, agent_model
+                )
+                car2_values, car2_log_prob = get_agent_values_from_observation(
+                    car2_observation, car2_action_array, agent_model
+                )
 
-        # Get agent values
-        if train_both or not training_master:
-            car1_values, car1_log_prob = get_agent_values_from_observation(car1_observation, car1_action_array, agent_model)
-            car2_values, car2_log_prob = get_agent_values_from_observation(car2_observation, car2_action_array, agent_model)
+            env_action = (car1_scalar_action, car2_scalar_action)
 
         env.render()
 
-        car1_next_obs, car2_next_obs, reward, done, truncated, info = env.step((car1_scalar_action, car2_scalar_action))
+        car1_next_obs, car2_next_obs, reward, done, truncated, info = env.step(env_action)
         episode_sum_of_rewards += reward
         all_rewards.append(reward)
-        actions_per_episode.append(car1_scalar_action)
+        if use_master_actions:
+            actions_per_episode.append(env_action)
+        else:
+            actions_per_episode.append(env_action[0])
 
         if done and info.get("crashed", False):
             crashed = True
@@ -58,13 +75,36 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         episode_start = (steps_counter == 1)
         all_drivers_states = reshape_drivers_states(all_drivers_states)
 
-        if train_both:
-            agent_model.rollout_buffer.add(car1_observation, car1_action_array, reward, episode_start, car1_values, car1_log_prob)
-            master_model.rollout_buffer.add(all_drivers_states, embedding, reward, episode_start, value, log_prob)
+        if use_master_actions:
+            master_model.rollout_buffer.add(
+                all_drivers_states,
+                np.array(master_output),
+                reward,
+                episode_start,
+                value,
+                log_prob,
+            )
+        elif train_both:
+            agent_model.rollout_buffer.add(
+                car1_observation,
+                car1_action_array,
+                reward,
+                episode_start,
+                car1_values,
+                car1_log_prob,
+            )
+            master_model.rollout_buffer.add(all_drivers_states, master_output, reward, episode_start, value, log_prob)
         elif training_master:
-            master_model.rollout_buffer.add(all_drivers_states, embedding, reward, episode_start, value, log_prob)
+            master_model.rollout_buffer.add(all_drivers_states, master_output, reward, episode_start, value, log_prob)
         else:
-            agent_model.rollout_buffer.add(car1_observation, car1_action_array, reward, episode_start, car1_values, car1_log_prob)
+            agent_model.rollout_buffer.add(
+                car1_observation,
+                car1_action_array,
+                reward,
+                episode_start,
+                car1_values,
+                car1_log_prob,
+            )
 
         car1_observation = car1_next_obs
         car2_observation = car2_next_obs  # TODO: make is generic for more than car1

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -29,15 +29,14 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         # Get all drivers states (without master embedding) from environment
         all_drivers_states = env.env.current_state
 
-        # Compute master embedding & (for later optionally use) its value/log_prob
-        master_output, value, log_prob = master_model.get_proto_action(ensure_tensor(all_drivers_states))
-
         if use_master_actions:
-            action_dim = getattr(experiment, 'MASTER_ACTION_DIM', len(master_output))
-            threshold = getattr(experiment, 'MASTER_ACTION_THRESHOLD', 0.0)
-            master_actions = Driver.convert_master_output_to_actions(master_output, action_dim, threshold)
-            env_action = tuple(int(a) for a in master_actions)
+            master_output = env.env.last_master_output
+            value = env.env.last_master_value
+            log_prob = env.env.last_master_log_prob
+            env_action = env.env.get_current_master_action_tuple()
         else:
+            # Compute master embedding & (for later optionally use) its value/log_prob
+            master_output, value, log_prob = master_model.get_proto_action(ensure_tensor(all_drivers_states))
             car1_action, car2_action = Driver.get_action(
                 agent_model,
                 car1_observation,
@@ -65,7 +64,7 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         episode_sum_of_rewards += reward
         all_rewards.append(reward)
         if use_master_actions:
-            actions_per_episode.append(env_action)
+            actions_per_episode.append(env.env.last_applied_action_tuple)
         else:
             actions_per_episode.append(env_action[0])
 

--- a/src/training/general_utils.py
+++ b/src/training/general_utils.py
@@ -5,6 +5,7 @@ import torch
 from stable_baselines3.common.logger import configure
 
 from src.model.agent_handler import Driver, DummyVecEnv
+from src.model.master_action_model import ActionMasterModel
 from src.model.master_model import MasterModel
 from src.model.model_handler import Model
 
@@ -107,12 +108,21 @@ def initialize_models(experiment_config, env_config):
 
     # === MASTER MODEL CONFIGURATION ===
     obs_dim = experiment_config.CARS_AMOUNT * 4
-    emb_dim = experiment_config.EMBEDDING_SIZE
+    use_master_actions = getattr(experiment_config, 'USE_MASTER_ACTIONS', False)
 
-    master_model = MasterModel(
-        observation_dim=obs_dim,
-        embedding_dim=emb_dim,
-    )
+    if use_master_actions:
+        action_dim = getattr(experiment_config, 'MASTER_ACTION_DIM', experiment_config.EMBEDDING_SIZE)
+        master_model = ActionMasterModel(
+            observation_dim=obs_dim,
+            action_dim=action_dim,
+            experiment=experiment_config,
+        )
+    else:
+        emb_dim = experiment_config.EMBEDDING_SIZE
+        master_model = MasterModel(
+            observation_dim=obs_dim,
+            embedding_dim=emb_dim,
+        )
 
     # === AGENT MODEL CONFIGsURATION ===
     AGENT_NETWORK_ARCH = {

--- a/src/training/training_handler.py
+++ b/src/training/training_handler.py
@@ -29,13 +29,21 @@ def training_loop(experiment, env, agent_model, master_model):
     """
 
     collision_counter, episode_counter, total_steps = 0, 0, 0
+    use_master_actions = getattr(experiment, 'USE_MASTER_ACTIONS', False)
 
     results = init_training_results()
 
     for cycle_num in range(1, experiment.CYCLES + 1):
         print('Cycle', cycle_num,'out of ', experiment.CYCLES)
-        train_both, training_master, training_agent = prepare_models_for_cycle(cycle_num, experiment.CYCLES,
-                                                                               master_model, agent_model)
+        train_both, training_master, training_agent = prepare_models_for_cycle(
+            cycle_num, experiment.CYCLES, master_model, agent_model
+        )
+
+        if use_master_actions:
+            train_both, training_master, training_agent = False, True, False
+            master_model.unfreeze()
+            if agent_model is not None and hasattr(agent_model, 'policy'):
+                agent_model.policy.set_training_mode(False)
         for _ in range(experiment.EPISODES_PER_CYCLE):
 
             episode_counter += 1


### PR DESCRIPTION
## Summary
- add a master action experiment configuration that switches the master output from embeddings to acceleration decisions
- introduce an ActionMasterModel and update the driver and training loop to support master-controlled acceleration/deceleration
- expose the new experiment option from the main entrypoint while keeping existing experiments intact

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d2e7c4488c833289cc3d4145d3ade2