### PR TITLE
Refactor training to use master-only control

### DIFF
--- a/src/model/master_model.py
+++ b/src/model/master_model.py
@@ -58,7 +58,7 @@ class MasterModel:
     PURE SB3 PPO - NO CUSTOM ANYTHING
     """
 
-    def __init__(self, embedding_size=4, experiment=None, observation_dim=None, **kwargs):
+    def __init__(self, embedding_size=4, experiment=None, observation_dim=None, action_dim=None, **kwargs):
         # Accept all possible arguments for compatibility
         self.embedding_size = embedding_size
         self.experiment = experiment
@@ -73,13 +73,20 @@ class MasterModel:
         else:
             self.observation_dim = 20  # Default 5 cars * 4 features
 
+        if action_dim is not None:
+            self.action_dim = action_dim
+        elif experiment is not None:
+            self.action_dim = experiment.CARS_AMOUNT if hasattr(experiment, 'CARS_AMOUNT') else embedding_size
+        else:
+            self.action_dim = embedding_size
+
         # Create dummy environment for PPO
         dummy_env = gym.Env()
         dummy_env.observation_space = spaces.Box(
             low=-np.inf, high=np.inf, shape=(self.observation_dim,), dtype=np.float32
         )
         dummy_env.action_space = spaces.Box(
-            low=-1.0, high=1.0, shape=(embedding_size,), dtype=np.float32
+            low=-1.0, high=1.0, shape=(self.action_dim,), dtype=np.float32
         )
 
         # Get n_steps safely
@@ -182,6 +189,12 @@ class MasterModel:
 
             # Convert to numpy for the action (embedding)
             action_np = action.cpu().numpy()[0]
+            if len(action_np) < self.action_dim:
+                padded_action = np.zeros(self.action_dim)
+                padded_action[:len(action_np)] = action_np
+                action_np = padded_action
+            elif len(action_np) > self.action_dim:
+                action_np = action_np[:self.action_dim]
 
             # Keep value and log_prob as tensors
             value_tensor = value.cpu()
@@ -198,6 +211,7 @@ class MasterModel:
         self.model.save(path)
         custom_params = {
             "embedding_size": self.embedding_size,
+            "action_dim": self.action_dim,
         }
         torch.save(custom_params, f"{path}_custom_params.pt")
 
@@ -206,4 +220,5 @@ class MasterModel:
         self.model = PPO.load(path)
         if os.path.exists(f"{path}_custom_params.pt"):
             custom_params = torch.load(f"{path}_custom_params.pt")
-            self.embedding_size = custom_params["embedding_size"]
+            self.embedding_size = custom_params.get("embedding_size", self.embedding_size)
+            self.action_dim = custom_params.get("action_dim", self.action_dim)

--- a/src/plotting_utils/plotting_utils.py
+++ b/src/plotting_utils/plotting_utils.py
@@ -21,9 +21,9 @@ def plot_training_results(experiment, results, show_plots=True):
     master_policy_losses = results["master_policy_losses"]
     master_value_losses = results["master_value_losses"]
     master_total_losses = results["master_total_losses"]
-    agent_policy_losses = results["agent_policy_losses"]
-    agent_value_losses = results["agent_value_losses"]
-    agent_total_losses = results["agent_total_losses"]
+    agent_policy_losses = results.get("agent_policy_losses", [])
+    agent_value_losses = results.get("agent_value_losses", [])
+    agent_total_losses = results.get("agent_total_losses", [])
 
     # Create x-axis for episodes
     episodes = np.arange(1, len(episode_rewards) + 1)

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -36,16 +36,32 @@ def run_episode(experiment, env, master_model) -> Tuple[float, List[List[int]], 
         # log probability that are required for PPO training updates.
         raw_actions, value, log_prob = master_model.get_proto_action(master_input)
 
-        # Determine how many vehicles are actually present in the current state: for a
-        # multi-vehicle observation we use the number of rows, otherwise we fall back to
-        # the configured fleet size. This guards against mismatch between the current
-        # environment state and the master model's output dimensionality.
-        num_controlled = current_state.shape[0] if isinstance(current_state, np.ndarray) and current_state.ndim == 2 else experiment.CARS_AMOUNT
-        num_controlled = min(num_controlled, len(raw_actions))
+        # Determine the number of master-controlled vehicles directly from the
+        # environment so that we never override the behaviour of static cars that
+        # the scenario builder injects. Fallback to the configured fleet size only
+        # when the attribute is missing (e.g. during tests) and clamp to the amount
+        # of actions proposed by the master network to avoid index errors.
+        env_controlled = getattr(env, "controlled_vehicles", None)
+        expected_controlled = len(env_controlled) if env_controlled is not None else experiment.CARS_AMOUNT
+        available_actions = len(raw_actions)
+
+        if available_actions < expected_controlled:
+            missing = expected_controlled - available_actions
+            logger.warning(
+                "Master proposed %s actions for %s controlled vehicles; reusing the last proposal to pad the remaining %s.",
+                available_actions,
+                expected_controlled,
+                missing,
+            )
 
         # Convert each raw acceleration (positive -> accelerate, negative -> brake) to a
         # discrete binary action that the environment understands and record it for logging.
-        discrete_actions = [1 if raw_actions[i] >= 0 else 0 for i in range(num_controlled)]
+        discrete_actions = []
+        for idx in range(expected_controlled):
+            source_idx = min(idx, max(available_actions - 1, 0))
+            raw_action = raw_actions[source_idx] if available_actions > 0 else 0.0
+            discrete_actions.append(1 if raw_action >= 0 else 0)
+
         print(f"Step {steps_counter}: Master actions {discrete_actions}")
 
         next_state, reward, done, truncated, info = env.step(tuple(discrete_actions))

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -31,10 +31,20 @@ def run_episode(experiment, env, master_model) -> Tuple[float, List[List[int]], 
         steps_counter += 1
 
         master_input = ensure_tensor(current_state)
+        # Query the master policy for the raw (continuous) acceleration proposals for every
+        # vehicle that it believes it should control, alongside the state-value estimate and
+        # log probability that are required for PPO training updates.
         raw_actions, value, log_prob = master_model.get_proto_action(master_input)
 
+        # Determine how many vehicles are actually present in the current state: for a
+        # multi-vehicle observation we use the number of rows, otherwise we fall back to
+        # the configured fleet size. This guards against mismatch between the current
+        # environment state and the master model's output dimensionality.
         num_controlled = current_state.shape[0] if isinstance(current_state, np.ndarray) and current_state.ndim == 2 else experiment.CARS_AMOUNT
         num_controlled = min(num_controlled, len(raw_actions))
+
+        # Convert each raw acceleration (positive -> accelerate, negative -> brake) to a
+        # discrete binary action that the environment understands and record it for logging.
         discrete_actions = [1 if raw_actions[i] >= 0 else 0 for i in range(num_controlled)]
         print(f"Step {steps_counter}: Master actions {discrete_actions}")
 

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -1,106 +1,67 @@
 import logging
+from typing import List, Tuple
+
+import numpy as np
+
+from src.training.general_utils import ensure_tensor
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-import numpy as np
 
-from src import project_globals
-from src.model.agent_handler import Driver
-from src.project_globals import rollout_buffers
-from src.training.general_utils import ensure_tensor, get_agent_values_from_observation, get_scaler_action_and_action_array
-from src.training.rollout_buffer_utils import reset_all_buffers
+def _reshape_state(state: np.ndarray) -> np.ndarray:
+    if isinstance(state, np.ndarray) and state.ndim == 2:
+        return state.reshape(-1)
+    return np.array(state).reshape(-1)
 
 
-def reshape_drivers_states(all_drivers_states):
-    all_drivers_states = all_drivers_states.reshape(-1) if isinstance(all_drivers_states, np.ndarray) and len(all_drivers_states.shape) == 2 else all_drivers_states
-    return all_drivers_states
-
-
-def run_episode(experiment, total_steps, env, master_model, agent_model, train_both, training_master):
-    all_rewards, actions_per_episode = [], []
-    steps_counter, episode_sum_of_rewards = 0, 0
+def run_episode(experiment, env, master_model) -> Tuple[float, List[List[int]], int, bool, np.ndarray]:
+    """Execute a full episode using only the master policy."""
+    all_rewards: List[float] = []
+    actions_per_episode: List[List[int]] = []
+    steps_counter = 0
+    episode_sum_of_rewards = 0.0
     crashed = False
 
-    car_observations, _ = env.reset()
-    done, truncated = False, False
+    current_state, _ = env.reset()
+    current_state = np.array(current_state)
+    done = truncated = False
 
     while not done and not truncated:
         steps_counter += 1
 
-        # Get all drivers states (without master embedding) from environment
-        all_drivers_states = env.env.current_state
+        master_input = ensure_tensor(current_state)
+        raw_actions, value, log_prob = master_model.get_proto_action(master_input)
 
-        # Compute master embedding & (for later optionally use) its value/log_prob
-        embedding, value, log_prob = master_model.get_proto_action(ensure_tensor(all_drivers_states))
+        num_controlled = current_state.shape[0] if isinstance(current_state, np.ndarray) and current_state.ndim == 2 else experiment.CARS_AMOUNT
+        num_controlled = min(num_controlled, len(raw_actions))
+        discrete_actions = [1 if raw_actions[i] >= 0 else 0 for i in range(num_controlled)]
+        print(f"Step {steps_counter}: Master actions {discrete_actions}")
 
-        # Choose agent action and compute its metrics
-        actions = Driver.get_action(agent_model, car_observations, total_steps, experiment.EXPLORATION_EXPLOITATION_THRESHOLD)
-
-        cars_scalar_action, cars_action_arrays = [], []
-        for action in actions:
-            car_scalar_action, car_action_array = get_scaler_action_and_action_array(action)
-            cars_scalar_action.append(car_scalar_action)
-            cars_action_arrays.append(car_action_array)
-
-        #print(f"Actions: [{car1_scalar_action}, {car2_scalar_action}]")
-
-        # Get agent values
-        cars_values, cars_log_probas = [], []
-        if train_both or not training_master:
-            for car_index in range(len(car_observations)):
-                car_values, car_log_prob = get_agent_values_from_observation(car_observations[car_index],
-                                                                             cars_action_arrays[car_index],
-                                                                             agent_model)
-                cars_values.append(car_values)
-                cars_log_probas.append(car_log_prob)
-        env.render()
-
-        action_tuple = tuple(cars_scalar_action)
-        cars_next_obs, reward, done, truncated, info = env.step(action_tuple)
+        next_state, reward, done, truncated, info = env.step(tuple(discrete_actions))
         episode_sum_of_rewards += reward
         all_rewards.append(reward)
-        # actions_per_episode.append(car1_scalar_action)
+        actions_per_episode.append(discrete_actions)
 
         if done and info.get("crashed", False):
             crashed = True
 
-        episode_start = (steps_counter == 1)
-        all_drivers_states = reshape_drivers_states(all_drivers_states)
+        episode_start = steps_counter == 1
+        flattened_state = _reshape_state(current_state)
+        master_model.rollout_buffer.add(flattened_state, raw_actions, reward, episode_start, value, log_prob)
 
-        if train_both:  # added flag for arrived that turns True after one time of is_arrived, and add to buffer only if True (for car1 and car2)
-            for car_index in range(len(project_globals.after_is_arrived_flags)):
-                if not project_globals.after_is_arrived_flags[car_index]:
-                    rollout_buffers[car_index].add(car_observations[car_index], cars_action_arrays[car_index], reward,
-                                                   episode_start, cars_values[car_index], cars_log_probas[car_index])
-            master_model.rollout_buffer.add(all_drivers_states, embedding, reward, episode_start, value, log_prob)
-        elif training_master:
-            master_model.rollout_buffer.add(all_drivers_states, embedding, reward, episode_start, value, log_prob)
-        else:
-            for car_index in range(len(project_globals.after_is_arrived_flags)):
-                if not project_globals.after_is_arrived_flags[car_index]:
-                    rollout_buffers[car_index].add(car_observations[car_index], cars_action_arrays[car_index], reward,
-                                                   episode_start, cars_values[car_index], cars_log_probas[car_index])
+        current_state = np.array(next_state)
 
-        car_observations = cars_next_obs
-
-    return episode_sum_of_rewards, actions_per_episode, steps_counter, crashed
+    return episode_sum_of_rewards, actions_per_episode, steps_counter, crashed, current_state
 
 
-def process_episode(episode_idx, total_steps, env, master_model, agent_model, experiment, train_both, training_master):
-    """
-    Run an episode and log results.
-    Returns: (reward, actions, steps, crashed)
-    """
+def process_episode(episode_idx, env, master_model, experiment):
+    """Run an episode and log results."""
     master_model.rollout_buffer.reset()
-    reset_all_buffers()  # reset all buffers (for each Driver)
 
-    # TODO: Create an assert here to see that they are reset propely
-
-    reward, actions, steps, crashed = run_episode(experiment, total_steps, env, master_model, agent_model,
-                                                  train_both=train_both, training_master=training_master)
+    reward, actions, steps, crashed, final_state = run_episode(experiment, env, master_model)
     status = "Collision" if crashed else "Success"
 
     print(f"Episode {episode_idx} | Result: {status} | Reward: {reward} | Steps: {steps}")
 
-    return reward, actions, steps, crashed
+    return reward, actions, steps, crashed, final_state

--- a/src/training/general_utils.py
+++ b/src/training/general_utils.py
@@ -1,319 +1,74 @@
 import os
+from typing import Optional
 
+import gymnasium as gym
 import numpy as np
 import torch
 from stable_baselines3.common.logger import configure
 
-from src.model.agent_handler import Driver, DummyVecEnv
 from src.model.master_model import MasterModel
-from src.model.model_handler import Model
 
 
-def ensure_tensor(obs, target_dim=None):
+def ensure_tensor(obs, target_dim: Optional[int] = None) -> torch.Tensor:
     """Convert obs to a tensor and ensure the correct shape."""
     if isinstance(obs, np.ndarray):
         tensor = torch.tensor(obs, dtype=torch.float32)
-        if len(obs.shape) == 3 or (len(obs.shape) == 2 and obs.shape[0] > 1):
+        if tensor.ndim > 1:
             tensor = tensor.reshape(1, -1)
         else:
             tensor = tensor.unsqueeze(0)
     elif isinstance(obs, torch.Tensor):
-        tensor = obs
-        if len(obs.shape) == 3 or (len(obs.shape) == 2 and obs.shape[0] > 1):
+        tensor = obs.float()
+        if tensor.ndim > 1 and tensor.shape[0] > 1:
             tensor = tensor.reshape(1, -1)
-        else:
-            tensor = tensor.unsqueeze(0) if len(obs.shape) == 1 else obs
+        elif tensor.ndim == 1:
+            tensor = tensor.unsqueeze(0)
     else:
         tensor = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
+
     if target_dim is not None and tensor.shape[1] != target_dim:
         if tensor.shape[1] > target_dim:
             tensor = tensor[:, :target_dim]
         else:
-            pad = torch.zeros((1, target_dim - tensor.shape[1]), dtype=torch.float32)
+            pad = torch.zeros((tensor.shape[0], target_dim - tensor.shape[1]), dtype=torch.float32)
             tensor = torch.cat([tensor, pad], dim=1)
     return tensor
 
 
-def get_obs_of_agent(all_drivers_states, car_index):
-    """Flatten observation, taking the first car if multidimensional."""
-    if isinstance(all_drivers_states, np.ndarray):
-        if len(all_drivers_states.shape) == 2 and all_drivers_states.shape[0] > 1:
-            return all_drivers_states[car_index]
-
-
-def flatten_obs(obs, length=4):
-    """Flatten observation, taking the first car if multidimensional."""
-    if isinstance(obs, np.ndarray):
-        if len(obs.shape) == 2 and obs.shape[0] > 1:
-            return obs[0].flatten()[:length]
-        return obs[:length].flatten()
-    elif isinstance(obs, torch.Tensor):
-        obs = obs.cpu().numpy()
-        if len(obs.shape) == 2 and obs.shape[0] > 1:
-            return obs[0].flatten()[:length]
-        return obs[:length].flatten()
-    return np.zeros(length)
-
-
-def combine_agent_obs(car_state, embedding, expected_dim):
-    """Concatenate car state and embedding, ensuring correct dim."""
-    car_state = np.array(car_state).flatten()
-    embedding = np.array(embedding).flatten()
-    agent_obs = np.concatenate((car_state, embedding))
-    if agent_obs.shape[0] != expected_dim:
-        if agent_obs.shape[0] > expected_dim:
-            agent_obs = agent_obs[:expected_dim]
-        else:
-            pad = np.zeros(expected_dim - agent_obs.shape[0])
-            agent_obs = np.concatenate([agent_obs, pad])
-    return agent_obs
-
-
-def get_scaler_action_and_action_array(car_action):
-    # scaler action
-    scaler_action =  car_action[0] if (hasattr(car_action, 'shape') and len(car_action.shape) > 0) else \
-        (car_action[0] if isinstance(car_action, list) and len(car_action) > 0 else car_action)
-
-    # action array
-    if hasattr(car_action, 'shape') and len(car_action.shape) > 0:
-        action_array = np.array([[car_action[0]]])
-    elif isinstance(car_action, list) and len(car_action) > 0:
-        action_array = np.array([[car_action[0]]])
-    else:
-        action_array = np.array([[car_action]])
-
-    return scaler_action, action_array
-
-
-
-def get_agent_values_from_observation(car_observation, car_action_array, agent_model):
-    with torch.no_grad():
-        obs_tensor = torch.tensor(car_observation, dtype=torch.float32).unsqueeze(0)
-        car_values = agent_model.policy.predict_values(obs_tensor)
-        dist = agent_model.policy.get_distribution(obs_tensor)
-        log_prob = dist.log_prob(torch.tensor(car_action_array, dtype=torch.long))
-        return car_values, log_prob
-
-
-def setup_experiment_dirs(experiment_path):
+def setup_experiment_dirs(experiment_path: str) -> None:
     """Create experiment directory if it doesn't exist."""
     os.makedirs(experiment_path, exist_ok=True)
 
+
 def initialize_models(experiment_config, env_config):
-    """
-    Initialize master and agent models, each with tuned architectures and hyperparameters.
-    """
+    """Initialize the master model and the Highway environment."""
     experiment_config.CONFIG = env_config
 
-    # === MASTER MODEL CONFIGURATION ===
     obs_dim = experiment_config.CARS_AMOUNT * 4
-    emb_dim = experiment_config.EMBEDDING_SIZE
+    action_dim = experiment_config.CARS_AMOUNT
 
     master_model = MasterModel(
         observation_dim=obs_dim,
-        embedding_dim=emb_dim,
+        action_dim=action_dim,
+        experiment=experiment_config,
     )
 
-    # === AGENT MODEL CONFIGsURATION ===
-    AGENT_NETWORK_ARCH = {
-        'pi': [64, 256],
-        'vf': [64, 256]
-    }
-    AGENT_LR = 1e-3
-    AGENT_BATCH_SIZE = 32
-    env_fn = lambda: Driver(experiment_config, master_model=master_model)
-    wrapped_env = DummyVecEnv([env_fn])
+    env = gym.make(
+        'RELintersection-v0',
+        render_mode=experiment_config.RENDER_MODE,
+        config=env_config,
+    )
 
-    agent_additional_model_params = {
-        'gamma': 0.8,
-        'gae_lambda': 0.99,
-        'ent_coef': 0.1,
-        'clip_range': 0.9,
-        'vf_coef': 0.25,
-        'max_grad_norm': 0.5,
-    }
-
-    original_define_model_params = Model.define_model_params
-
-    @staticmethod
-    def improved_define_model_params(experiment):
-        params = original_define_model_params(experiment)
-        params.update(agent_additional_model_params)
-        params['learning_rate'] = AGENT_LR
-        params['batch_size']    = AGENT_BATCH_SIZE
-        params['policy_kwargs'] = dict(
-            activation_fn=torch.nn.ReLU,
-            net_arch=[dict(pi=AGENT_NETWORK_ARCH['pi'],
-                           vf=AGENT_NETWORK_ARCH['vf'])]
-        )
-        return params
-
-    Model.define_model_params = improved_define_model_params
-    agent_model = Model(wrapped_env, experiment_config).model
-    Model.define_model_params = original_define_model_params
-
-    return master_model, agent_model, wrapped_env
+    return master_model, env
 
 
-# def initialize_models(experiment_config, env_config):
-#     """
-#     Initialize master and agent models, each with tuned architectures and hyperparameters.
-#     """
-#     experiment_config.CONFIG = env_config
-#
-#     # === MASTER MODEL CONFIGURATION ===
-#     # - Slightly smaller network to avoid overfitting on the value function.
-#     # - Lower learning rate for more stable global value estimation.
-#     # - Higher batch size to smooth out the loss curve.
-#     MASTER_NETWORK_ARCH = [128, 128]
-#     MASTER_LR = 2e-5
-#     MASTER_BATCH_SIZE = 128
-#
-#     master_policy_kwargs = dict(
-#         activation_fn=torch.nn.ReLU,
-#         net_arch=MASTER_NETWORK_ARCH
-#     )
-#
-#     master_model = MasterModel(
-#         embedding_size=experiment_config.EMBEDDING_SIZE,
-#         experiment=experiment_config
-#     )
-#
-#     # === AGENT MODEL CONFIGURATION ===
-#     # - Larger network to capture complex state/action mapping.
-#     # - Slightly higher entropy for exploration.
-#     # - Lower learning rate for stability.
-#     # - Conservative PPO clipping.
-#     AGENT_NETWORK_ARCH = {
-#         'pi': [16,32,64,32,16],
-#         'vf': [16,32,64,32,16]
-#     }
-#     AGENT_LR = 0.05
-#     AGENT_BATCH_SIZE = 64
-#
-#     # Environment wrapper using the custom Driver class
-#     env_fn = lambda: Driver(experiment_config, master_model=master_model)
-#     wrapped_env = DummyVecEnv([env_fn])
-#
-#     agent_additional_model_params = {
-#         'gamma': 0.99,
-#         'gae_lambda': 0.95,
-#         'ent_coef': 0.2,
-#         'clip_range': 0.05
-#     }
-#
-#     # Patch model params definition for agent model
-#     original_define_model_params = Model.define_model_params
-#
-#     @staticmethod
-#     def improved_define_model_params(experiment):
-#         params = original_define_model_params(experiment)
-#         params.update(agent_additional_model_params)
-#         params['learning_rate'] = AGENT_LR
-#         params['batch_size'] = AGENT_BATCH_SIZE
-#         params['policy_kwargs'] = dict(
-#             activation_fn=torch.nn.ReLU,
-#             net_arch=[dict(
-#                 pi=AGENT_NETWORK_ARCH['pi'],
-#                 vf=AGENT_NETWORK_ARCH['vf']
-#             )]
-#         )
-#         return params
-#
-#     # Temporarily override static method for agent initialization
-#     Model.define_model_params = improved_define_model_params
-#
-#     # Initialize agent model with improved parameters
-#     agent_model = Model(wrapped_env, experiment_config).model
-#
-#     # Restore the original static method to avoid side effects
-#     Model.define_model_params = original_define_model_params
-#
-#     return master_model, agent_model, wrapped_env
-
-
-# def initialize_models(experiment_config, env_config):
-#     """Initialize master and agent models, and environment."""
-#     # Attach environment configuration for easy access
-#     experiment_config.CONFIG = env_config
-#     # Create master model
-#     master_model = MasterModel(
-#         embedding_size=experiment_config.EMBEDDING_SIZE,
-#         experiment=experiment_config
-#     )
-#     # Create env wrapper with Agent handler
-#     env_fn = lambda: Driver(experiment_config, master_model=master_model)
-#     wrapped_env = DummyVecEnv([env_fn])
-#     # Create agent model
-#
-
-#     return master_model, agent_model, wrapped_env
-
-
-def setup_loggers(base_path):
-    """Setup and return agent and master loggers."""
-    agent_logger = configure(os.path.join(base_path, "agent_logs"), ["stdout", "csv", "tensorboard"])
+def setup_loggers(base_path: str):
+    """Setup and return the master logger."""
     master_logger = configure(os.path.join(base_path, "master_logs"), ["stdout", "csv", "tensorboard"])
-    return agent_logger, master_logger
+    return master_logger
 
 
-def close_everything(env, agent_logger, master_logger):
-    """Close environment and loggers."""
+def close_everything(env, master_logger) -> None:
+    """Close environment and logger."""
     env.close()
-    agent_logger.close()
     master_logger.close()
-
-
-def monitor_episode_results(master_model, agent_model):
-    """Prints minimal statistics about the rollout buffers"""
-    master_buffer_size = master_model.rollout_buffer.pos
-    agent_buffer_size = agent_model.rollout_buffer.pos
-
-    print(f"Current buffer sizes - Master: {master_buffer_size}, Agent: {agent_buffer_size}")
-
-    if master_buffer_size > 0 and hasattr(master_model.rollout_buffer, 'rewards'):
-        rewards = master_model.rollout_buffer.rewards[:master_buffer_size]
-        print(f"Episode rewards - Min: {rewards.min():.2f}, Max: {rewards.max():.2f}, Avg: {rewards.mean():.2f}")
-
-
-def monitor_rollout_buffers(master_model, agent_model):
-    """Prints statistics about the rollout buffers for debugging"""
-    print("\n--- Rollout Buffer Statistics ---")
-
-    # Master buffer stats
-    print("Master rollout buffer:")
-    print(f"  Buffer size: {master_model.rollout_buffer.buffer_size}")
-    print(f"  Current position: {master_model.rollout_buffer.pos}")
-    print(f"  Is full: {master_model.rollout_buffer.full}")
-
-    if hasattr(master_model.rollout_buffer, 'observations') and master_model.rollout_buffer.observations is not None:
-        print(f"  Observations shape: {master_model.rollout_buffer.observations.shape}")
-
-    if hasattr(master_model.rollout_buffer, 'actions') and master_model.rollout_buffer.actions is not None:
-        print(f"  Actions shape: {master_model.rollout_buffer.actions.shape}")
-
-    if hasattr(master_model.rollout_buffer, 'rewards') and master_model.rollout_buffer.rewards is not None:
-        rewards = master_model.rollout_buffer.rewards[:master_model.rollout_buffer.pos]
-        if len(rewards) > 0:
-            print(f"  Rewards stats: min={rewards.min():.4f}, max={rewards.max():.4f}, mean={rewards.mean():.4f}")
-            print(f"  Rewards: {rewards}")
-
-    # Agent buffer stats
-    print("\nAgent rollout buffer:")
-    print(f"  Buffer size: {agent_model.rollout_buffer.buffer_size}")
-    print(f"  Current position: {agent_model.rollout_buffer.pos}")
-    print(f"  Is full: {agent_model.rollout_buffer.full}")
-
-    if hasattr(agent_model.rollout_buffer, 'observations') and agent_model.rollout_buffer.observations is not None:
-        print(f"  Observations shape: {agent_model.rollout_buffer.observations.shape}")
-
-    if hasattr(agent_model.rollout_buffer, 'actions') and agent_model.rollout_buffer.actions is not None:
-        print(f"  Actions shape: {agent_model.rollout_buffer.actions.shape}")
-
-    if hasattr(agent_model.rollout_buffer, 'rewards') and agent_model.rollout_buffer.rewards is not None:
-        rewards = agent_model.rollout_buffer.rewards[:agent_model.rollout_buffer.pos]
-        if len(rewards) > 0:
-            print(f"  Rewards stats: min={rewards.min():.4f}, max={rewards.max():.4f}, mean={rewards.mean():.4f}")
-            print(f"  Rewards: {rewards}")
-
-    print("-------------------------------\n")

--- a/src/training/training_handler.py
+++ b/src/training/training_handler.py
@@ -1,20 +1,19 @@
 import logging
+from typing import Tuple
 
-import numpy as np
-import torch
-from gymnasium import spaces
-from stable_baselines3.common.buffers import RolloutBuffer
-
-from src.model.model_handler import load_models, save_models
 from src.plotting_utils.plotting_utils import plot_training_results
-from src.project_globals import rollout_buffers
 from src.training.episode_utils import process_episode
 from src.training.general_utils import (
     setup_experiment_dirs,
     initialize_models,
     setup_loggers,
-    close_everything, ensure_tensor, )
-from src.training.training_loop_utils import init_training_results, prepare_models_for_cycle, perform_training_phase
+    close_everything,
+)
+from src.training.training_loop_utils import (
+    init_training_results,
+    prepare_master_for_cycle,
+    perform_training_phase,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -24,194 +23,69 @@ logger = logging.getLogger(__name__)
 # Training Loop
 ##########################################
 
-def training_loop(experiment, env, agent_model, master_model):
-    """
-    Main training loop that orchestrates cycles and episodes.
-    """
 
-    # Add rollout buffer per controlled car
-    for _ in env.env.config["controlled_cars"]:
-        new_rollout_buffer_instance = RolloutBuffer(
-            buffer_size=experiment.N_STEPS,
-            observation_space=spaces.Box(low=-np.inf, high=np.inf, shape=(experiment.STATE_INPUT_SIZE,)),
-            action_space=spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32),
-            gamma=0.99,
-            gae_lambda=0.95,
-            n_envs=1
-        )
-        rollout_buffers.append(new_rollout_buffer_instance)
+def training_loop(experiment, env, master_model):
+    """Main training loop that orchestrates cycles and episodes."""
 
-    collision_counter, episode_counter, total_steps = 0, 0, 0
+    collision_counter = 0
+    episode_counter = 0
 
     results = init_training_results()
 
     for cycle_num in range(1, experiment.CYCLES + 1):
         print('Cycle', cycle_num, 'out of ', experiment.CYCLES)
-        train_both, training_master, training_agent = prepare_models_for_cycle(cycle_num, experiment.CYCLES,
-                                                                               master_model, agent_model)
-        for _ in range(experiment.EPISODES_PER_CYCLE):
+        prepare_master_for_cycle(cycle_num, experiment.CYCLES, master_model)
 
+        for _ in range(experiment.EPISODES_PER_CYCLE):
             episode_counter += 1
             print()
             print("*" * 40)
             print('Episode ', episode_counter, '/', experiment.EPISODES_PER_CYCLE * experiment.CYCLES, 'episodes')
             print("*" * 40)
             print()
-            episode_rewards, actions, steps, crashed = process_episode(episode_counter, total_steps, env, master_model,
-                                                                       agent_model, experiment, train_both,
-                                                                       training_master)
+
+            episode_reward, actions, steps, crashed, final_state = process_episode(
+                episode_counter,
+                env,
+                master_model,
+                experiment,
+            )
+
             if crashed:
                 collision_counter += 1
 
-            total_steps += steps
-            results["episode_rewards"].append(episode_rewards)
+            results["episode_rewards"].append(episode_reward)
             results["all_actions"].append(actions)
 
-            # Prepare state for training
-            with torch.no_grad():
-                _, _ = env.reset()
-                full_state = env.env.current_state
-                state_tensor = ensure_tensor(full_state)
-
             if episode_counter % experiment.EPISODE_AMOUNT_FOR_TRAIN == 0:
-                perform_training_phase(train_both, training_master, training_agent, master_model, agent_model,
-                                       full_state,
-                                       state_tensor, results)
+                perform_training_phase(master_model, final_state, results)
 
     print("Training completed.")
-    return agent_model, master_model, collision_counter, results["episode_rewards"], results["all_actions"], results
-
-
-#
-# def training_loop(experiment, env, agent_model, master_model):
-#     """
-#     Main training loop that orchestrates cycles and episodes.
-#     """
-#
-#     collision_counter, episode_counter, total_steps = 0, 0, 0
-#
-#     results = init_training_results()
-#
-#     for cycle_num in range(1, experiment.CYCLES + 1):
-#         print('Cycle', cycle_num,'out of ', experiment.CYCLES)
-#         train_both, training_master, training_agent = prepare_models_for_cycle(cycle_num, experiment.CYCLES,
-#                                                                                master_model, agent_model)
-#         for _ in range(experiment.EPISODES_PER_CYCLE):
-#
-#             episode_counter += 1
-#             print('This is the ',episode_counter,'Out of',experiment.EPISODES_PER_CYCLE* experiment.CYCLES, 'episodes')
-#             episode_rewards, actions, steps, crashed = process_episode(episode_counter, total_steps, env, master_model,
-#                                                               agent_model, experiment, train_both, training_master)
-#             if crashed:
-#                 collision_counter += 1
-#
-#             total_steps += steps
-#             results["episode_rewards"].append(episode_rewards)
-#             results["all_actions"].append(actions)
-#
-#             # Prepare state for training
-#             with torch.no_grad():
-#                 _, _, _ = env.reset()
-#                 full_state = env.env.current_state
-#                 state_tensor = ensure_tensor(full_state)
-#
-#             if episode_counter % Experiment.EPISODE_AMOUNT_FOR_TRAIN == 0 :
-#                 perform_training_phase(train_both, training_master, training_agent, master_model, agent_model, full_state,
-#                                        state_tensor, results)
-#
-#     print("Training completed.")
-#     return agent_model, master_model, collision_counter, results["episode_rewards"], results["all_actions"], results
-
-
-##########################################
-# Evaluation
-##########################################
-
-def run_evaluation(experiment_config, env, agent_model):
-    """Run evaluation episodes in inference mode"""
-    eval_rewards = []
-    eval_actions = []
-    eval_episodes = getattr(experiment_config, 'EVAL_EPISODES', 5)  # Default to 5
-
-    for episode in range(eval_episodes):
-        print(f"Evaluation episode {episode + 1}/{eval_episodes}")
-        obs, _ = env.reset()
-        done = False
-        truncated = False
-        episode_reward = 0
-        actions = []
-
-        while not done and not truncated:
-            action, _ = agent_model.predict(obs, deterministic=True)
-            obs, reward, done, truncated, info = env.step(action)
-            episode_reward += reward
-            actions.append(action[0])
-            env.render()
-
-        eval_rewards.append(episode_reward)
-        eval_actions.append(actions)
-        print(f"Episode {episode + 1} reward: {episode_reward}")
-        print(f"Success: {not info.get('crashed', False)}")
-
-    print(f"Average evaluation reward: {np.mean(eval_rewards)}")
-    return eval_rewards, eval_actions
-
-
-##########################################
-# Inference & Training Mode Handlers
-##########################################
-
-def run_inference_mode(experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger):
-    """Run inference episodes only."""
-    if experiment_config.LOAD_PREVIOUS_WEIGHT and experiment_config.LOAD_MODEL_DIRECTORY:
-        loaded = load_models(agent_model, master_model, experiment_config.LOAD_MODEL_DIRECTORY)
-        if loaded:
-            print("Models will be trained from loaded weights!")
-        else:
-            print("Starting inference with untrained models.")
-    else:
-        print("Starting inference with untrained models (No previous weights loaded)")
-
-    eval_rewards, eval_actions = run_evaluation(experiment_config, wrapped_env, agent_model)
-    close_everything(wrapped_env, agent_logger, master_logger)
-    return agent_model, master_model, 0
-
-
-def run_training_mode(experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger):
-    """Run the training loop and handle saving/logging."""
-    agent_model, master_model, collision_counter, all_rewards, all_actions, training_results = (
-        training_loop(experiment=experiment_config, env=wrapped_env, agent_model=agent_model,
-                      master_model=master_model))
-    save_models(agent_model, master_model, experiment_config.SAVE_MODEL_DIRECTORY)
-    plot_training_results(experiment_config, training_results, show_plots=True)
-    # log_training_results_to_neptune(experiment_config.logger, training_results)
-    print("Training completed.")
-    print("Total collisions:", collision_counter)
-    # close_everything(wrapped_env, agent_logger, master_logger)
-    return agent_model, master_model, collision_counter
+    return master_model, collision_counter, results
 
 
 ##########################################
 # Main experiment entrypoint
 ##########################################
 
-def run_experiment(experiment_config, env_config):
+
+def run_experiment(experiment_config, env_config) -> Tuple[object, int, dict]:
     print(
         f"Environment configuration: {len(env_config['controlled_cars'])} controlled cars, {len(env_config['static_cars'])} static cars"
     )
     setup_experiment_dirs(experiment_config.EXPERIMENT_PATH)
-    master_model, agent_model, wrapped_env = initialize_models(experiment_config, env_config)
-    agent_logger, master_logger = setup_loggers(experiment_config.EXPERIMENT_PATH)
-    agent_model.set_logger(agent_logger)
+    master_model, env = initialize_models(experiment_config, env_config)
+    master_logger = setup_loggers(experiment_config.EXPERIMENT_PATH)
     master_model.set_logger(master_logger)
 
-    if experiment_config.ONLY_INFERENCE:
-        print("Running in inference-only mode")
-        return run_inference_mode(
-            experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger
-        )
-    else:
-        print("Running in training mode")
-        return run_training_mode(
-            experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger
-        )
+    print("Running in training mode")
+    master_model, collision_counter, training_results = training_loop(
+        experiment=experiment_config,
+        env=env,
+        master_model=master_model,
+    )
+    plot_training_results(experiment_config, training_results, show_plots=True)
+    print("Training completed.")
+    print("Total collisions:", collision_counter)
+    close_everything(env, master_logger)
+    return master_model, collision_counter, training_results

--- a/src/training/training_loop_utils.py
+++ b/src/training/training_loop_utils.py
@@ -1,77 +1,45 @@
 import logging
-import traceback
-from typing import Tuple, List, Dict, Any
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
 
-from src.training.general_utils import ensure_tensor, flatten_obs, combine_agent_obs
+from src.training.general_utils import ensure_tensor
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def init_training_results() -> Dict[str, List[Any]]:
-    """
-    Initialize the structure for tracking training results.
-    """
+    """Initialize the structure for tracking training results."""
     return {
         "episode_rewards": [],
         "master_policy_losses": [],
         "master_value_losses": [],
         "master_total_losses": [],
-        "agent_policy_losses": [],
-        "agent_value_losses": [],
-        "agent_total_losses": [],
-        "all_actions": []
+        "all_actions": [],
     }
 
 
-def prepare_models_for_cycle(
-    cycle_num: int,
-    total_cycles: int,
-    master_model,
-    agent_model
-) -> Tuple[bool, bool, bool]:
-    """
-    Determine which networks to train this cycle and set freeze/unfreeze states.
-    Returns flags: (train_both, training_master, training_agent)
-    """
+def prepare_master_for_cycle(cycle_num: int, total_cycles: int, master_model) -> None:
+    """Log cycle progress and ensure the master is trainable."""
     print(f"Cycle {cycle_num}/{total_cycles}")
-    train_both = cycle_num == 1
-    training_master = not train_both and (cycle_num % 2 == 0)
-    training_agent = not train_both and (cycle_num % 2 == 1)
-
-    # Freeze/unfreeze master and set agent training mode
-    if train_both or training_master:
-        master_model.unfreeze()
-    else:
-        master_model.freeze()
-    agent_model.policy.set_training_mode(train_both or training_agent)
-
-    return train_both, training_master, training_agent
+    master_model.unfreeze()
 
 
-def record_losses(
-    losses: Tuple[float, float, float] or None,
-    policy_list: List[Any],
-    value_list: List[Any],
-    total_list: List[Any]
-) -> None:
-    """
-    Append losses or None to tracking lists.
-    """
+def record_losses(losses: Optional[List[float]], results: Dict[str, List[Any]]) -> None:
+    """Append loss values (or None) to the tracking structure."""
     policy_loss = value_loss = total_loss = None
     if losses:
         policy_loss, value_loss, total_loss = losses
-    policy_list.append(policy_loss)
-    value_list.append(value_loss)
-    total_list.append(total_loss)
+
+    results["master_policy_losses"].append(policy_loss)
+    results["master_value_losses"].append(value_loss)
+    results["master_total_losses"].append(total_loss)
 
 
-
-
-def train_master_and_reset_buffer(master_model, full_obs):
-    """Trains the master model and resets its buffer - Returns loss values"""
+def train_master_and_reset_buffer(master_model, full_obs) -> Optional[List[float]]:
+    """Train the master model using the accumulated rollout buffer."""
     policy_loss_val = value_loss_val = total_loss_val = None
     try:
         with torch.no_grad():
@@ -120,14 +88,13 @@ def train_master_and_reset_buffer(master_model, full_obs):
                 policy_loss_val = policy_loss.item()
                 value_loss_val = value_loss.item()
                 total_loss_val = loss.item()
-                #print(
-                #    f"Master loss - Policy: {policy_loss_val:.4f}, Value: {value_loss_val:.4f}, Total: {total_loss_val:.4f}")
             else:
                 print("Master model: No valid data for training")
         finally:
             master_model.rollout_buffer.get = orig_get
     except Exception as e:
         print(f"Error during master training: {str(e)}")
+        import traceback
         traceback.print_exc()
     master_model.rollout_buffer.reset()
     print("Master buffer reset")
@@ -136,190 +103,7 @@ def train_master_and_reset_buffer(master_model, full_obs):
     return None
 
 
-
-def train_agent_and_reset_buffer(master_model, agent_model, last_master_tensor):
-    """Trains the agent model and resets its buffer - Returns loss values"""
-    from src.project_globals import rollout_buffers
-
-    for current_rollout_buffer in rollout_buffers:
-
-        policy_loss_val = value_loss_val = total_loss_val = None
-        try:
-            with torch.no_grad():
-                shaped_tensor = ensure_tensor(last_master_tensor)
-                embedding, _, _ = master_model.get_proto_action(shaped_tensor)
-                car_state = flatten_obs(last_master_tensor)
-                expected_dim = agent_model.policy.observation_space.shape[0]
-                agent_obs = combine_agent_obs(car_state, embedding, expected_dim)
-                agent_obs_tensor = torch.tensor(agent_obs, dtype=torch.float32).unsqueeze(0)
-                last_value = agent_model.policy.predict_values(agent_obs_tensor)
-
-            if current_rollout_buffer.pos == 0:
-                print("Agent model: No data to train on")
-                return None
-
-            current_rollout_buffer.compute_returns_and_advantage(last_value, np.array([True]))
-            orig_get = current_rollout_buffer.get
-
-            def modified_get(batch_size):
-                if not current_rollout_buffer.full:
-                    orig_full = current_rollout_buffer.full
-                    current_rollout_buffer.full = True
-                    try:
-                        indices = np.arange(current_rollout_buffer.pos)
-                        if len(indices) > 0:
-                            return current_rollout_buffer._get_samples(indices)
-                        else:
-                            return None
-                    finally:
-                        current_rollout_buffer.full = orig_full
-                else:
-                    return next(orig_get(batch_size))
-
-            try:
-                current_rollout_buffer.get = modified_get
-                rollout_data = current_rollout_buffer.get(batch_size=None)
-                if rollout_data is not None:
-                    steps_trained = len(rollout_data.observations)
-                    print(f"Agent model trained on {steps_trained} steps")
-                    observations_tensor = torch.FloatTensor(rollout_data.observations)
-                    actions_tensor = torch.FloatTensor(rollout_data.actions)
-                    policy = agent_model.policy
-                    optimizer = policy.optimizer
-                    values, log_probs, entropy = policy.evaluate_actions(observations_tensor, actions_tensor)
-                    value_loss = ((values - torch.FloatTensor(rollout_data.returns)) ** 2).mean()
-                    advantages_tensor = torch.FloatTensor(rollout_data.advantages)
-                    policy_loss = -(log_probs * advantages_tensor).mean()
-                    entropy_loss = -entropy.mean()
-                    loss = policy_loss + 0.5 * value_loss + 0.01 * entropy_loss
-                    optimizer.zero_grad()
-                    loss.backward()  # TODO: log the losses better
-                    torch.nn.utils.clip_grad_norm_(policy.parameters(), 0.5)
-                    optimizer.step()
-                    policy_loss_val = policy_loss.item()
-                    value_loss_val = value_loss.item()
-                    total_loss_val = loss.item()
-                    print(
-                        f"Agent loss - Policy: {policy_loss_val:.4f}, Value: {value_loss_val:.4f}, Total: {total_loss_val:.4f}")
-                else:
-                    print("Agent model: No valid data for training")
-            finally:
-                current_rollout_buffer.get = orig_get
-        except Exception as e:
-            print(f"Error during agent training: {str(e)}")
-            traceback.print_exc()
-        current_rollout_buffer.reset()
-        print("Agent buffer reset")
-
-
-    if policy_loss_val is not None:
-        return [policy_loss_val, value_loss_val, total_loss_val]
-    return None
-
-#
-# def train_agent_and_reset_buffer(master_model, agent_model, last_master_tensor):
-#     """Trains the agent model and resets its buffer - Returns loss values"""
-#     policy_loss_val = value_loss_val = total_loss_val = None
-#     try:
-#         with torch.no_grad():
-#             shaped_tensor = ensure_tensor(last_master_tensor)
-#             embedding, _, _ = master_model.get_proto_action(shaped_tensor)
-#             car_state = flatten_obs(last_master_tensor)
-#             expected_dim = agent_model.policy.observation_space.shape[0]
-#             agent_obs = combine_agent_obs(car_state, embedding, expected_dim)
-#             agent_obs_tensor = torch.tensor(agent_obs, dtype=torch.float32).unsqueeze(0)
-#             last_value = agent_model.policy.predict_values(agent_obs_tensor)
-#         if agent_model.rollout_buffer.pos == 0:
-#             print("Agent model: No data to train on")
-#             return None
-#         agent_model.rollout_buffer.compute_returns_and_advantage(last_value, np.array([True]))
-#         orig_get = agent_model.rollout_buffer.get
-#
-#         def modified_get(batch_size):
-#             if not agent_model.rollout_buffer.full:
-#                 orig_full = agent_model.rollout_buffer.full
-#                 agent_model.rollout_buffer.full = True
-#                 try:
-#                     indices = np.arange(agent_model.rollout_buffer.pos)
-#                     if len(indices) > 0:
-#                         return agent_model.rollout_buffer._get_samples(indices)
-#                     else:
-#                         return None
-#                 finally:
-#                     agent_model.rollout_buffer.full = orig_full
-#             else:
-#                 return next(orig_get(batch_size))
-#
-#         try:
-#             agent_model.rollout_buffer.get = modified_get
-#             rollout_data = agent_model.rollout_buffer.get(batch_size=None)
-#             if rollout_data is not None:
-#                 steps_trained = len(rollout_data.observations)
-#                 print(f"Agent model trained on {steps_trained} steps")
-#                 observations_tensor = torch.FloatTensor(rollout_data.observations)
-#                 actions_tensor = torch.FloatTensor(rollout_data.actions)
-#                 policy = agent_model.policy
-#                 optimizer = policy.optimizer
-#                 values, log_probs, entropy = policy.evaluate_actions(observations_tensor, actions_tensor)
-#                 value_loss = ((values - torch.FloatTensor(rollout_data.returns)) ** 2).mean()
-#                 advantages_tensor = torch.FloatTensor(rollout_data.advantages)
-#                 policy_loss = -(log_probs * advantages_tensor).mean()
-#                 entropy_loss = -entropy.mean()
-#                 loss = policy_loss + 0.5 * value_loss + 0.01 * entropy_loss
-#                 optimizer.zero_grad()
-#                 loss.backward()
-#                 torch.nn.utils.clip_grad_norm_(policy.parameters(), 0.5)
-#                 optimizer.step()
-#                 policy_loss_val = policy_loss.item()
-#                 value_loss_val = value_loss.item()
-#                 total_loss_val = loss.item()
-#                 #print(
-#                 #    f"Agent loss - Policy: {policy_loss_val:.4f}, Value: {value_loss_val:.4f}, Total: {total_loss_val:.4f}")
-#             else:
-#                 print("Agent model: No valid data for training")
-#         finally:
-#             agent_model.rollout_buffer.get = orig_get
-#     except Exception as e:
-#         print(f"Error during agent training: {str(e)}")
-#         traceback.print_exc()
-#     agent_model.rollout_buffer.reset()
-#     print("Agent buffer reset")
-#     if policy_loss_val is not None:
-#         return [policy_loss_val, value_loss_val, total_loss_val]
-#     return None
-
-
-
-
-def perform_training_phase(
-    train_both: bool,
-    training_master: bool,
-    training_agent: bool,
-    master_model,
-    agent_model,
-    full_state: Any,
-    state_tensor: torch.Tensor,
-    results: Dict[str, List[Any]]) -> None:
-    """
-    Execute training for master and/or agent and update results.
-    """
-    master_losses = None
-    agent_losses = None
-    if train_both or training_master:
-        master_losses = train_master_and_reset_buffer(master_model, full_state)
-    if train_both or training_agent:
-        agent_losses = train_agent_and_reset_buffer(master_model, agent_model, state_tensor)
-
-    record_losses(
-        master_losses,
-        results["master_policy_losses"],
-        results["master_value_losses"],
-        results["master_total_losses"]
-    )
-    record_losses(
-        agent_losses,
-        results["agent_policy_losses"],
-        results["agent_value_losses"],
-        results["agent_total_losses"]
-    )
-
+def perform_training_phase(master_model, full_state, results: Dict[str, List[Any]]) -> None:
+    """Execute master training and log the resulting losses."""
+    master_losses = train_master_and_reset_buffer(master_model, full_state)
+    record_losses(master_losses, results)


### PR DESCRIPTION
## Summary
- update the master PPO to emit per-vehicle acceleration decisions and persist the action dimensionality
- remove the agent network pipeline so episodes execute and train directly from the master model while logging chosen actions
- streamline training utilities, handlers, and plots for the master-only workflow and guard plotting against missing agent losses

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ee09004e348332a733507fd3e3fdc3