### PR TITLE
Add SafeR-ADAIM training stack and documentation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,53 @@
+# SafeR-ADAIM Design Mapping
+
+## High-Level Architecture
+1. **Environment Adaptation** – `src/safe_radaim/env_wrapper.py` wraps the
+   patched `IntersectionEnv` to expose the SafeR-ADAIM state, action and
+   cost interfaces. It installs the new
+   `ExpectedVelocityMultiAgentAction` (`highwayenv/custom_action.py`) so the
+   policy can output desired velocities directly.
+2. **Neural Modules** – `src/safe_radaim/networks.py` implements the
+   Gaussian policy, reward value and cost value networks that mirror the
+   architecture specified in the paper.
+3. **Algorithm Core** – `src/safe_radaim/algorithm.py` houses the
+   Risk Situation-aware Constrained Policy Optimisation (RSCPO) update.
+   It computes gradients, classifies the risk case, solves the dual for the
+   moderate-risk regime and performs constrained line-search.
+4. **Trajectory Loop** – `src/safe_radaim/training.py` collects
+   on-policy trajectories, estimates reward/cost advantages and orchestrates
+   policy/value updates via `SafeRADAIMAgent`.
+5. **Entrypoint** – `safe_radaim_main.py` builds the wrapped environment,
+   initialises the agent with `SafeRADAIMConfig`, runs training through
+   `SafeRADAIMTrainer` and saves the resulting PyTorch weights under
+   `experiments/`.
+
+## Key Data Flows
+1. `gym.make('RELintersection-v0')` → `SafeIntersectionEnv` translates raw
+   vehicle kinematics into `[d, v, β_onehot]` feature vectors and derives
+   dense/sparse costs.
+2. `SafeRADAIMTrainer` (per epoch):
+   * collects `steps_per_epoch` transitions using `SafeRADAIMAgent.act`;
+   * converts them into a `TrajectoryBatch` (states, actions, rewards,
+     costs, log-probs, advantages, targets);
+   * calls `agent.update_values` then `agent.update_policy`.
+3. `agent.update_policy`:
+   * computes policy gradient `g`, cost gradient `b` and Hessian-vector
+     products via conjugate gradients;
+   * classifies the risk regime and computes the step direction;
+   * runs line-search constrained by KL and estimated post-update cost;
+   * writes the updated parameters back into the policy network.
+
+## External Interfaces
+* **Configuration** – `src/safe_radaim/config.py` exposes tunable defaults
+  (reward/cost coefficients, cost limit, network widths). `SafeRADAIMConfig`
+  can be customised via CLI arguments in `safe_radaim_main.py`.
+* **Outputs** – serialized PyTorch weights (`safe_radaim_policy.pt`,
+  `safe_radaim_value.pt`, `safe_radaim_cost_value.pt`) and stdout logging of
+  epoch metrics (reward, cost, KL, risk case).
+
+## Integration Points
+* The wrapper preserves compatibility with the existing experiment config
+  (`src/experiment/scenarios_config.py`) so SafeR-ADAIM reuses the same
+  scenario definitions.
+* Existing PPO-based pipeline remains untouched; SafeR-ADAIM lives alongside
+  the original training stack, enabling side-by-side comparisons.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,39 @@
+# SafeR-ADAIM Migration Plan
+
+## Objectives
+* Introduce the SafeR-ADAIM control stack alongside the existing PPO
+  training code without disrupting current workflows.
+* Provide a clear path for replacing or augmenting the legacy agent with
+  the SafeR-ADAIM agent in experiments.
+
+## Steps
+1. **Environment Preparation**
+   * Ensure `highwayenv` patches are loaded via `patch_intersection_env()`
+     and `register_intersection_env()`.
+   * Use `SafeIntersectionEnv` to wrap any existing intersection scenarios.
+     The wrapper accepts the same configuration dictionaries already used in
+     `scenarios_config`.
+2. **Training Pipeline**
+   * Instantiate `SafeRADAIMAgent` with observation/action dimensions derived
+     from the wrapped environment.
+   * Configure rollout length, velocity bounds and reward/cost coefficients
+     through `SafeRADAIMConfig`.
+   * Use `SafeRADAIMTrainer` to run training epochs. The trainer collects
+     trajectories, updates the value networks and then applies the RSCPO step.
+3. **Evaluation / Deployment**
+   * After training, load the serialized weights saved in `experiments/`.
+   * Re-wrap the environment in inference mode and feed observations through
+     the trained policy to obtain desired velocities.
+4. **Coexistence with PPO**
+   * The original PPO training loop (`main.py`) remains untouched. Teams can
+     run PPO-based experiments in parallel with SafeR-ADAIM by choosing the
+     appropriate entrypoint.
+   * Shared assets (scenario definitions, vehicle classes, logging directory)
+     remain compatible across both pipelines.
+
+## Validation
+* Run `python safe_radaim_main.py --epochs 1 --steps-per-epoch 128` to
+  perform a smoke test. Confirm that artefacts are saved and KL/cost metrics
+  are reported.
+* Compare collision rates between PPO and SafeR-ADAIM by reusing the same
+  environment seeds, leveraging the unified wrappers for a fair comparison.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,63 @@
+# SafeR-ADAIM Specification
+
+## Problem Statement
+Autonomous intersection management (AIM) must coordinate connected and
+automated vehicles (CAVs) through all-direction turn lane (ADTL)
+intersections without traffic signals. Traditional optimization-based
+methods ensure safety but are computationally expensive, while reward-only
+reinforcement learning (RL) approaches often neglect safety constraints.
+Safe Reinforced All-Directional AIM (SafeR-ADAIM) combines risk-sensitive
+policy optimization with multi-objective reward design to deliver safe,
+efficient and comfortable intersection crossing in unpredictable traffic.
+
+## Environment Abstraction
+* **State** `S=[d, v, β]` – for each controlled vehicle: distance to exit
+  along route (`d`), current speed (`v`) and turn intention (`β` as left,
+  straight or right one-hot encoded). State is concatenated for all
+  controlled vehicles.
+* **Action** `A=[v'_i]` – desired velocity per vehicle in metres per
+  second, bounded between `[v_min, v_max]`. The environment converts the
+  desired speed into throttle/brake inputs via the existing PID controller.
+* **Reward** – sum of three components evaluated per episode:
+  * Efficiency `R_eff`: dense speed incentive with sparse bonuses for
+    individual and collective completion.
+  * Comfort `R_comfort`: penalties proportional to acceleration and jerk
+    magnitudes.
+  * Safety `R_safety = -C_total` uses the same costs defined below.
+* **Cost** – separate dense collision-risk cost (distance threshold) and
+  sparse collision cost. The cumulative cost is constrained during policy
+  updates.
+
+## Algorithmic Overview
+SafeR-ADAIM is built on Risk Situation-aware Constrained Policy
+Optimization (RSCPO):
+1. Collect on-policy trajectories using a Gaussian policy.
+2. Estimate reward and cost advantages with GAE.
+3. Compute policy gradient `g` and cost gradient `b`.
+4. Approximate the Fisher information via the Hessian of the KL divergence
+   using conjugate gradients.
+5. Classify the current policy risk level with
+   `c_hat = J_C(π) - d` and `F = δ - (c_hat^2)/(b^T H^{-1} b)`.
+   * **Risk-free** (`c_hat < 0`, `F > 0`): TRPO-style step.
+   * **Moderate risk** (`c_hat > 0`, `F > 0`): solve the dual to blend
+     reward and cost gradients while respecting constraints.
+   * **High risk** (`F ≤ 0`): step along the cost gradient to re-enter the
+     feasible region.
+6. Use backtracking line-search to satisfy KL and cost limits.
+7. Update reward and cost value networks via MSE regression.
+
+## Hyper-parameters (adapted defaults)
+* Policy/value hidden widths: `[128, 128]` (policy/value), `[128, 128, 128, 128]` (cost value).
+* Rollout length: `2048` steps per epoch, `γ=0.99`, `λ=0.95` for both
+  reward and cost.
+* Trust-region radius: `δ = 0.01`.
+* Cost limit per epoch: `0.01` (tunable per scenario).
+* Dense reward/cost coefficients derived from the paper (ε_v, ε_t,
+  ε_pass_single, ε_pass_all, ε_a, ε_j, ε_d, ε_c).
+
+## Expected Outputs
+* Learned Gaussian policy mapping the SafeR-ADAIM state into desired
+  velocities.
+* Reward, cost and KL diagnostics for each epoch.
+* Serialized PyTorch weights for policy, reward value and cost value
+  networks.

--- a/highwayenv/custom_action.py
+++ b/highwayenv/custom_action.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from highway_env.envs.common.abstract import AbstractEnv
-from highway_env.envs.common.action import ActionType, ContinuousAction, DiscreteAction, DiscreteMetaAction, \
-    MultiAgentAction
+from highway_env.envs.common.action import (
+    ActionType,
+    ContinuousAction,
+    DiscreteAction,
+    DiscreteMetaAction,
+    MultiAgentAction,
+)
 
 import functools
 import itertools
-from typing import TYPE_CHECKING, Callable, Union
+from typing import TYPE_CHECKING, Callable, Iterable, Union
 
 import numpy as np
 from gymnasium import spaces
@@ -75,16 +80,17 @@ def action_factory(env: AbstractEnv, config: dict) -> ActionType:
         return ContinuousAction(env, **config)
     if config["type"] == "DiscreteAction":
         return DiscreteAction(env, **config)
-    elif config["type"] == "DiscreteMetaAction":
+    if config["type"] == "DiscreteMetaAction":
         return DiscreteMetaAction(env, **config)
-    elif config["type"] == "MultiAgentAction":
+    if config["type"] == "MultiAgentAction":
         return MultiAgentAction(env, **config)
-    elif config["type"] == "CustomDiscreteAction":
+    if config["type"] == "CustomDiscreteAction":
         return CustomDiscreteAction(env, **config)
-    elif config["type"] == "CustomMultiAgentAction":
+    if config["type"] == "CustomMultiAgentAction":
         return CustomMultiAgentAction(env, **config)
-    else:
-        raise ValueError("Unknown action type")
+    if config["type"] == "ExpectedVelocityMultiAgentAction":
+        return ExpectedVelocityMultiAgentAction(env, **config)
+    raise ValueError("Unknown action type")
 
 
 class CustomMultiAgentAction(ActionType):
@@ -135,3 +141,69 @@ class CustomMultiAgentAction(ActionType):
     #     return itertools.product(
     #         *[action_type.get_available_actions() for action_type in self.agents_action_types]
     #     )
+
+
+class ExpectedVelocityAction(ActionType):
+    """Control a single vehicle using desired velocity commands."""
+
+    def __init__(self, env: AbstractEnv, *, min_velocity: float, max_velocity: float) -> None:
+        super().__init__(env)
+        self.min_velocity = float(min_velocity)
+        self.max_velocity = float(max_velocity)
+
+    def space(self) -> spaces.Space:
+        return spaces.Box(
+            low=np.array([self.min_velocity], dtype=np.float32),
+            high=np.array([self.max_velocity], dtype=np.float32),
+            dtype=np.float32,
+        )
+
+    @property
+    def vehicle_class(self) -> Callable:
+        return CustomDiscreteAction(self.env, target_speeds=[self.max_velocity]).vehicle_class
+
+    def act(self, action: np.ndarray | float) -> None:
+        desired = np.clip(float(np.asarray(action).squeeze()), self.min_velocity, self.max_velocity)
+        vehicle = self.controlled_vehicle
+        vehicle.target_speed = desired
+        vehicle.max_speed = max(vehicle.max_speed, desired)
+        vehicle.act(None)
+
+
+class ExpectedVelocityMultiAgentAction(ActionType):
+    """Apply expected velocity control to all controlled vehicles."""
+
+    def __init__(self, env: AbstractEnv, config: dict | None = None, **kwargs) -> None:
+        super().__init__(env)
+        cfg = dict(config or {})
+        cfg.update(kwargs)
+        self.min_velocity = float(cfg.get("min_velocity", 0.0))
+        self.max_velocity = float(cfg.get("max_velocity", 15.0))
+        self.actions: list[ExpectedVelocityAction] = []
+        for vehicle in self.env.controlled_vehicles:
+            action = ExpectedVelocityAction(
+                env,
+                min_velocity=self.min_velocity,
+                max_velocity=self.max_velocity,
+            )
+            action.controlled_vehicle = vehicle
+            self.actions.append(action)
+
+    def space(self) -> spaces.Space:
+        lows = np.full(len(self.actions), self.min_velocity, dtype=np.float32)
+        highs = np.full(len(self.actions), self.max_velocity, dtype=np.float32)
+        return spaces.Box(low=lows, high=highs, dtype=np.float32)
+
+    @property
+    def vehicle_class(self) -> Callable:
+        return ExpectedVelocityAction(
+            self.env,
+            min_velocity=self.min_velocity,
+            max_velocity=self.max_velocity,
+        ).vehicle_class
+
+    def act(self, action: np.ndarray | Iterable[float]) -> None:
+        values = np.asarray(action, dtype=np.float32).reshape(-1)
+        assert values.shape[0] == len(self.actions), "Expected velocity per controlled vehicle"
+        for value, action_type in zip(values, self.actions):
+            action_type.act(value)

--- a/safe_radaim_main.py
+++ b/safe_radaim_main.py
@@ -1,0 +1,82 @@
+"""Entry-point for training the SafeR-ADAIM agent."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import copy
+
+import torch
+
+from highwayenv.utils import patch_intersection_env, register_intersection_env
+
+from src.experiment import scenarios_config
+from src.safe_radaim import (
+    SafeIntersectionEnv,
+    SafeRADAIMAgent,
+    SafeRADAIMConfig,
+    SafeRADAIMTrainer,
+    SafeRADAIMTrainSettings,
+)
+
+
+def build_environment(config: SafeRADAIMConfig) -> SafeIntersectionEnv:
+    patch_intersection_env()
+    register_intersection_env()
+    base_env = copy.deepcopy(scenarios_config.full_env_config_exp5)
+    import gymnasium as gym
+
+    env = gym.make("RELintersection-v0", render_mode=None, config=base_env)
+    return SafeIntersectionEnv(
+        env,
+        min_velocity=config.min_velocity,
+        max_velocity=config.max_velocity,
+        epsilon_distance_cost=config.epsilon_distance_cost,
+        epsilon_collision_cost=config.epsilon_collision_cost,
+        epsilon_v=config.epsilon_v,
+        epsilon_t=config.epsilon_t,
+        epsilon_pass_single=config.epsilon_pass_single,
+        epsilon_pass_all=config.epsilon_pass_all,
+        epsilon_a=config.epsilon_a,
+        epsilon_j=config.epsilon_j,
+        safe_distance=config.safe_distance,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train SafeR-ADAIM agent")
+    parser.add_argument("--epochs", type=int, default=32, help="Number of training epochs")
+    parser.add_argument("--steps-per-epoch", type=int, default=1024, help="Environment steps per epoch")
+    parser.add_argument("--device", type=str, default="cpu", help="Computation device")
+    args = parser.parse_args()
+
+    config = SafeRADAIMConfig(
+        epochs=args.epochs,
+        steps_per_epoch=args.steps_per_epoch,
+        device=args.device,
+    )
+
+    env = build_environment(config)
+    obs_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.shape[0]
+
+    agent = SafeRADAIMAgent(obs_dim=obs_dim, action_dim=action_dim, config=config)
+    settings = SafeRADAIMTrainSettings(total_epochs=config.epochs)
+    trainer = SafeRADAIMTrainer(env=env, agent=agent, config=config, settings=settings)
+    stats = trainer.train()
+
+    output_dir = Path("experiments")
+    output_dir.mkdir(exist_ok=True)
+    torch.save(agent.networks.policy.state_dict(), output_dir / "safe_radaim_policy.pt")
+    torch.save(agent.networks.value_fn.state_dict(), output_dir / "safe_radaim_value.pt")
+    torch.save(agent.networks.cost_value_fn.state_dict(), output_dir / "safe_radaim_cost_value.pt")
+
+    for entry in stats:
+        print(
+            f"Epoch {entry.epoch}: reward={entry.total_reward:.2f} cost={entry.total_cost:.2f} "
+            f"KL={entry.policy_info.kl_divergence:.4f} case={entry.policy_info.case}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/safe_radaim/__init__.py
+++ b/src/safe_radaim/__init__.py
@@ -1,0 +1,14 @@
+"""SafeR-ADAIM algorithm implementation package."""
+
+from .config import SafeRADAIMConfig, SafeRADAIMTrainSettings
+from .algorithm import SafeRADAIMAgent
+from .training import SafeRADAIMTrainer
+from .env_wrapper import SafeIntersectionEnv
+
+__all__ = [
+    "SafeRADAIMConfig",
+    "SafeRADAIMTrainSettings",
+    "SafeRADAIMAgent",
+    "SafeRADAIMTrainer",
+    "SafeIntersectionEnv",
+]

--- a/src/safe_radaim/algorithm.py
+++ b/src/safe_radaim/algorithm.py
@@ -1,0 +1,227 @@
+"""SafeR-ADAIM algorithm implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from .config import SafeRADAIMConfig
+from .networks import GaussianPolicy, SafeRADAIMNetworks, ValueFunction
+from .utils import TrajectoryBatch, conjugate_gradients, flatten_tensors, unflatten_tensors
+
+
+@dataclass
+class PolicyUpdateInfo:
+    """Diagnostics from a policy update step."""
+
+    surrogate_reward: float
+    surrogate_cost: float
+    kl_divergence: float
+    case: str
+    backtracks: int
+
+
+class SafeRADAIMAgent:
+    """Risk Situation-aware Constrained Policy Optimization agent."""
+
+    def __init__(self, obs_dim: int, action_dim: int, config: SafeRADAIMConfig) -> None:
+        self.config = config
+        self.device = torch.device(config.device)
+        self.networks = SafeRADAIMNetworks(
+            policy=GaussianPolicy(obs_dim, config.policy_hidden_sizes, action_dim),
+            value_fn=ValueFunction(obs_dim, config.value_hidden_sizes),
+            cost_value_fn=ValueFunction(obs_dim, config.cost_value_hidden_sizes),
+        ).to(self.device)
+        self.value_optimizer = optim.Adam(self.networks.value_fn.parameters(), lr=config.value_lr)
+        self.cost_value_optimizer = optim.Adam(
+            self.networks.cost_value_fn.parameters(), lr=config.cost_value_lr
+        )
+
+    # ------------------------------------------------------------------
+    # trajectory utilities
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def act(self, obs: np.ndarray) -> Tuple[np.ndarray, float]:
+        observation = torch.as_tensor(obs, dtype=torch.float32, device=self.device)
+        action, log_prob, _ = self.networks.policy.sample(observation.unsqueeze(0))
+        return action.squeeze(0).cpu().numpy(), float(log_prob.item())
+
+    def evaluate_policy(self, batch: TrajectoryBatch) -> Tuple[torch.Tensor, torch.Tensor]:
+        dist = self.networks.policy.distribution(batch.observations)
+        log_probs = dist.log_prob(batch.actions).sum(dim=-1)
+        return log_probs, dist
+
+    # ------------------------------------------------------------------
+    # training steps
+    # ------------------------------------------------------------------
+    def update_values(self, batch: TrajectoryBatch) -> Dict[str, float]:
+        results: Dict[str, float] = {}
+        value_loss_fn = nn.MSELoss()
+
+        value_pred = self.networks.value_fn(batch.observations)
+        value_loss = value_loss_fn(value_pred, batch.reward_targets)
+        self.value_optimizer.zero_grad()
+        value_loss.backward()
+        self.value_optimizer.step()
+        results["value_loss"] = float(value_loss.item())
+
+        cost_pred = self.networks.cost_value_fn(batch.observations)
+        cost_loss = value_loss_fn(cost_pred, batch.cost_targets)
+        self.cost_value_optimizer.zero_grad()
+        cost_loss.backward()
+        self.cost_value_optimizer.step()
+        results["cost_value_loss"] = float(cost_loss.item())
+
+        return results
+
+    def update_policy(self, batch: TrajectoryBatch) -> PolicyUpdateInfo:
+        observations = batch.observations
+        actions = batch.actions
+        old_log_probs = batch.log_probs
+        reward_adv = batch.reward_advantages
+        cost_adv = batch.cost_advantages
+
+        reward_adv = (reward_adv - reward_adv.mean()) / (reward_adv.std() + 1e-8)
+        cost_adv = cost_adv - cost_adv.mean()
+
+        dist = self.networks.policy.distribution(observations)
+        dist_old = torch.distributions.Normal(dist.loc.detach(), dist.scale.detach())
+        log_probs = dist.log_prob(actions).sum(dim=-1)
+
+        def policy_loss_fn():
+            ratio = torch.exp(log_probs - old_log_probs)
+            return -(ratio * reward_adv).mean()
+
+        def cost_surrogate():
+            ratio = torch.exp(log_probs - old_log_probs)
+            return (ratio * cost_adv).mean()
+
+        policy_loss = policy_loss_fn()
+        g = flatten_tensors(torch.autograd.grad(policy_loss, self.networks.policy.parameters(), create_graph=True))
+
+        cost_loss = cost_surrogate()
+        b = flatten_tensors(torch.autograd.grad(cost_loss, self.networks.policy.parameters(), create_graph=True))
+
+        with torch.no_grad():
+            mean_cost = float(batch.costs.mean().item())
+        c_hat = mean_cost - self.config.cost_limit
+
+        def hessian_vector_product(v: torch.Tensor) -> torch.Tensor:
+            kl = self._kl_divergence(observations, dist_old)
+            grads = torch.autograd.grad(kl, self.networks.policy.parameters(), create_graph=True)
+            flat_grad = flatten_tensors(grads)
+            kl_v = (flat_grad * v).sum()
+            hvp = torch.autograd.grad(kl_v, self.networks.policy.parameters())
+            return flatten_tensors(hvp) + self.config.damping_coeff * v
+
+        x = conjugate_gradients(hessian_vector_product, g, self.config.cg_iters)
+        xHx = torch.dot(x, hessian_vector_product(x))
+
+        y = conjugate_gradients(hessian_vector_product, b, self.config.cg_iters)
+        bHb = torch.dot(b, y)
+        gHy = torch.dot(g, y)
+
+        c_hat = float(c_hat)
+        bHb = float(bHb.item())
+        gHx = float(xHx.item())
+        gHy = float(gHy.item())
+
+        F = self.config.max_kl - (c_hat**2) / (bHb + 1e-8)
+
+        if c_hat < 0 and F > 0:
+            step_dir = torch.sqrt(torch.tensor(2 * self.config.max_kl / (gHx + 1e-8))) * x
+            case = "risk_free"
+        elif c_hat > 0 and F > 0:
+            A = gHx
+            B = gHy
+            C = bHb
+            denom = max(self.config.max_kl - c_hat**2 / (C + 1e-8), 1e-8)
+            lam = torch.sqrt(torch.tensor(max(A - (B**2) / (C + 1e-8), 0.0) / denom))
+            nu = (B + c_hat * lam) / (C + 1e-8)
+            step_dir = lam * (x - nu * y)
+            case = "moderate_risk"
+        else:
+            step_dir = -torch.sqrt(torch.tensor(2 * self.config.max_kl / (bHb + 1e-8))) * y
+            case = "high_risk"
+
+        step_dir = step_dir.detach()
+
+        old_params = flatten_tensors(self.networks.policy.parameters()).detach()
+        new_params, backtracks, surrogate_reward, surrogate_cost, kl = self._line_search(
+            observations,
+            actions,
+            old_log_probs,
+            reward_adv,
+            cost_adv,
+            dist_old,
+            mean_cost,
+            old_params,
+            step_dir,
+            case,
+        )
+
+        self._assign_params(new_params)
+        return PolicyUpdateInfo(
+            surrogate_reward=surrogate_reward,
+            surrogate_cost=surrogate_cost,
+            kl_divergence=kl,
+            case=case,
+            backtracks=backtracks,
+        )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _assign_params(self, flat: torch.Tensor) -> None:
+        params = list(self.networks.policy.parameters())
+        for param, value in zip(params, unflatten_tensors(flat, params)):
+            param.data.copy_(value.data)
+
+    def _kl_divergence(self, observations: torch.Tensor, dist_old) -> torch.Tensor:
+        dist_new = self.networks.policy.distribution(observations)
+        kl = torch.distributions.kl_divergence(dist_old, dist_new)
+        return kl.mean()
+
+    def _line_search(
+        self,
+        observations: torch.Tensor,
+        actions: torch.Tensor,
+        old_log_probs: torch.Tensor,
+        reward_adv: torch.Tensor,
+        cost_adv: torch.Tensor,
+        dist_old,
+        mean_cost: float,
+        old_params: torch.Tensor,
+        step_dir: torch.Tensor,
+        case: str,
+    ) -> Tuple[torch.Tensor, int, float, float, float]:
+        step = 1.0
+        backtracks = 0
+        best_reward = -np.inf
+        best_cost = np.inf
+        best_kl = np.inf
+        params = list(self.networks.policy.parameters())
+        for backtracks in range(self.config.max_line_search_steps):
+            new_params = old_params + step * step_dir
+            for param, value in zip(params, unflatten_tensors(new_params, params)):
+                param.data.copy_(value.data)
+
+            dist_new = self.networks.policy.distribution(observations)
+            new_log_probs = dist_new.log_prob(actions).sum(dim=-1)
+            ratio = torch.exp(new_log_probs - old_log_probs)
+            surrogate_reward = float((ratio * reward_adv).mean().item())
+            surrogate_cost = float((ratio * cost_adv).mean().item())
+            kl = float(torch.distributions.kl_divergence(dist_old, dist_new).mean().item())
+
+            new_cost_estimate = mean_cost + surrogate_cost
+            cost_ok = case != "moderate_risk" or new_cost_estimate <= self.config.cost_limit
+            if kl <= self.config.max_kl and cost_ok:
+                best_reward, best_cost, best_kl = surrogate_reward, surrogate_cost, kl
+                return new_params, backtracks, best_reward, best_cost, best_kl
+            step *= self.config.line_search_coeff
+        return old_params, backtracks + 1, best_reward, best_cost, best_kl
+

--- a/src/safe_radaim/config.py
+++ b/src/safe_radaim/config.py
@@ -1,0 +1,77 @@
+"""Configuration dataclasses for SafeR-ADAIM."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass
+class SafeRADAIMConfig:
+    """Hyper-parameters and environment settings for SafeR-ADAIM.
+
+    These defaults are derived from the paper and adapted to the
+    intersection benchmark contained in this repository. The defaults keep
+    the same hidden layer sizes as the paper (two 128-unit hidden layers
+    for policy/value networks and a deeper cost network) while exposing
+    the reward and cost shaping parameters that appear in Section V-A of
+    the paper.
+    """
+
+    # rollout / training
+    epochs: int = 512
+    steps_per_epoch: int = 2048
+    gamma: float = 0.99
+    cost_gamma: float = 0.99
+    gae_lambda: float = 0.95
+    cost_gae_lambda: float = 0.95
+    line_search_coeff: float = 0.8
+    max_line_search_steps: int = 10
+    damping_coeff: float = 0.1
+    cg_iters: int = 15
+    max_kl: float = 0.01
+
+    # safety constraint (per epoch average cost limit)
+    cost_limit: float = 0.01
+
+    # learning rates for value networks
+    value_lr: float = 3e-4
+    cost_value_lr: float = 3e-4
+
+    # neural network widths
+    policy_hidden_sizes: Sequence[int] = field(default_factory=lambda: (128, 128))
+    value_hidden_sizes: Sequence[int] = field(default_factory=lambda: (128, 128))
+    cost_value_hidden_sizes: Sequence[int] = field(default_factory=lambda: (128, 128, 128, 128))
+
+    # action bounds for expected velocity outputs (m/s)
+    min_velocity: float = 0.0
+    max_velocity: float = 15.0
+
+    # reward shaping parameters (Section V-A of the paper)
+    epsilon_v: float = 0.1
+    epsilon_t: float = 0.05
+    epsilon_pass_single: float = 1.0
+    epsilon_pass_all: float = 3.0
+    epsilon_a: float = -0.05
+    epsilon_j: float = -0.02
+
+    # dense / sparse cost increments
+    epsilon_distance_cost: float = 1.0
+    epsilon_collision_cost: float = 10.0
+
+    safe_distance: float = 5.0
+
+    # training control
+    device: str = "cpu"
+
+    # logging
+    log_interval: int = 10
+
+
+@dataclass
+class SafeRADAIMTrainSettings:
+    """High level toggles for the SafeR-ADAIM trainer."""
+
+    total_epochs: int = 128
+    evaluate_every: int = 32
+    evaluation_episodes: int = 5
+

--- a/src/safe_radaim/env_wrapper.py
+++ b/src/safe_radaim/env_wrapper.py
@@ -1,0 +1,272 @@
+"""Environment wrapper exposing the state/action spaces expected by SafeR-ADAIM."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+
+from highwayenv.custom_action import ExpectedVelocityMultiAgentAction
+
+
+@dataclass
+class RewardBreakdown:
+    efficiency: float
+    comfort: float
+    safety: float
+
+
+class SafeIntersectionEnv(gym.Env):
+    """Wrap ``IntersectionEnv`` to expose SafeR-ADAIM signals.
+
+    The wrapper augments the original environment with:
+
+    * a continuous action space representing desired velocities for all
+      controlled vehicles;
+    * a global observation vector with distances-to-exit, speeds and turn
+      intentions encoded for every controlled vehicle;
+    * dense and sparse cost terms derived from vehicle spacing and
+      collisions, matching the definitions from the paper.
+    """
+
+    metadata = {"render_modes": ["human", None]}
+
+    def __init__(
+        self,
+        base_env: gym.Env,
+        *,
+        min_velocity: float,
+        max_velocity: float,
+        epsilon_distance_cost: float,
+        epsilon_collision_cost: float,
+        epsilon_v: float,
+        epsilon_t: float,
+        epsilon_pass_single: float,
+        epsilon_pass_all: float,
+        epsilon_a: float,
+        epsilon_j: float,
+        safe_distance: float,
+    ) -> None:
+        super().__init__()
+        self.base_env = base_env
+        self.min_velocity = min_velocity
+        self.max_velocity = max_velocity
+        self.epsilon_distance_cost = epsilon_distance_cost
+        self.epsilon_collision_cost = epsilon_collision_cost
+        self.epsilon_v = epsilon_v
+        self.epsilon_t = epsilon_t
+        self.epsilon_pass_single = epsilon_pass_single
+        self.epsilon_pass_all = epsilon_pass_all
+        self.epsilon_a = epsilon_a
+        self.epsilon_j = epsilon_j
+        self.safe_distance = safe_distance
+        policy_freq = float(self.base_env.config.get("policy_frequency", 5))
+        self._dt = 1.0 / policy_freq if policy_freq > 0 else 0.1
+
+        if not hasattr(self.base_env, "config"):
+            raise TypeError("Expected a highway-env style environment with 'config'")
+
+        # swap-in the expected velocity action model
+        action_config = {
+            "type": "ExpectedVelocityMultiAgentAction",
+            "min_velocity": min_velocity,
+            "max_velocity": max_velocity,
+        }
+        self._action_config = action_config
+        self.base_env.config = dict(self.base_env.config)
+        self.base_env.config["action"] = action_config
+        self.base_env.action_type = ExpectedVelocityMultiAgentAction(self.base_env, action_config)
+
+        self._controlled: List = list(self.base_env.controlled_vehicles)
+        self._num_controlled = len(self._controlled)
+
+        self.action_space = spaces.Box(
+            low=np.full(self._num_controlled, min_velocity, dtype=np.float32),
+            high=np.full(self._num_controlled, max_velocity, dtype=np.float32),
+            dtype=np.float32,
+        )
+
+        # per-vehicle features: distance, speed, one-hot turn intention (3)
+        self._features_per_vehicle = 5
+        self.observation_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(self._num_controlled * self._features_per_vehicle,),
+            dtype=np.float32,
+        )
+
+        self._previous_speeds = np.zeros(self._num_controlled, dtype=np.float32)
+        self._previous_accels = np.zeros(self._num_controlled, dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # gym.Env API
+    # ------------------------------------------------------------------
+    def reset(self, *, seed: int | None = None, options: Dict | None = None):
+        obs, info = self.base_env.reset(seed=seed, options=options)
+        self.base_env.action_type = ExpectedVelocityMultiAgentAction(
+            self.base_env, self._action_config
+        )
+        self._controlled = list(self.base_env.controlled_vehicles)
+        self._num_controlled = len(self._controlled)
+        self._previous_speeds = self._extract_speeds()
+        self._previous_accels = np.zeros_like(self._previous_speeds)
+        return self._build_observation(), info
+
+    def step(self, action: np.ndarray):
+        action = np.asarray(action, dtype=np.float32)
+        assert action.shape == (self._num_controlled,), "Action must match number of controlled vehicles"
+
+        obs, base_reward, terminated, truncated, info = self.base_env.step(action)
+        current_speeds = self._extract_speeds()
+        accelerations = (current_speeds - self._previous_speeds) / self._dt
+        jerk = (accelerations - self._previous_accels) / self._dt
+
+        dense_cost = self._compute_risk_cost()
+        collision_cost = self._compute_collision_cost(info)
+        total_cost = dense_cost + collision_cost
+
+        reward_breakdown = self._compute_reward_components(
+            current_speeds=current_speeds,
+            accelerations=accelerations,
+            jerk=jerk,
+            dense_cost=dense_cost + collision_cost,
+        )
+        reward = reward_breakdown.efficiency + reward_breakdown.comfort + reward_breakdown.safety
+
+        self._previous_speeds = current_speeds
+        self._previous_accels = accelerations
+
+        info = dict(info or {})
+        info.update(
+            {
+                "reward_breakdown": reward_breakdown,
+                "risk_cost": float(total_cost),
+                "dense_cost": float(dense_cost),
+                "collision_cost": float(collision_cost),
+                "base_reward": base_reward,
+            }
+        )
+
+        return self._build_observation(), reward, terminated, truncated, info
+
+    def render(self):
+        return self.base_env.render()
+
+    def close(self):
+        return self.base_env.close()
+
+    # ------------------------------------------------------------------
+    # feature engineering
+    # ------------------------------------------------------------------
+    def _build_observation(self) -> np.ndarray:
+        features: List[float] = []
+        for vehicle in self._controlled:
+            distance = self._distance_to_exit(vehicle)
+            speed = float(np.linalg.norm(vehicle.velocity))
+            intention = self._turn_intention(vehicle)
+            features.extend([distance, speed, *intention])
+        return np.asarray(features, dtype=np.float32)
+
+    def _extract_speeds(self) -> np.ndarray:
+        return np.array([np.linalg.norm(vehicle.velocity) for vehicle in self._controlled], dtype=np.float32)
+
+    def _distance_to_exit(self, vehicle) -> float:
+        lane = self.base_env.road.network.get_lane(vehicle.lane_index)
+        local_s, _ = lane.local_coordinates(vehicle.position)
+        remaining = max(lane.length - local_s, 0.0)
+        if getattr(vehicle, "route", None):
+            for step in vehicle.route[1:]:
+                lane_key = step if isinstance(step, tuple) else step
+                try:
+                    next_lane = self.base_env.road.network.get_lane(lane_key)
+                except KeyError:
+                    continue
+                remaining += getattr(next_lane, "length", 0.0)
+        return float(remaining)
+
+    def _turn_intention(self, vehicle) -> Tuple[float, float, float]:
+        route = getattr(vehicle, "route", None)
+        if not route or len(route) < 2:
+            return (0.0, 1.0, 0.0)  # assume straight
+        current_lane = route[0]
+        next_lane = route[1]
+        current_dir = self._lane_direction(current_lane)
+        next_dir = self._lane_direction(next_lane)
+        if current_dir is None or next_dir is None:
+            return (0.0, 1.0, 0.0)
+        diff = (next_dir - current_dir) % 4
+        if diff == 0:
+            return (0.0, 1.0, 0.0)
+        if diff == 1:
+            return (1.0, 0.0, 0.0)  # left
+        if diff == 3:
+            return (0.0, 0.0, 1.0)  # right
+        return (0.0, 1.0, 0.0)
+
+    @staticmethod
+    def _lane_direction(lane_key) -> int | None:
+        if isinstance(lane_key, tuple):
+            lane_key = lane_key[0]
+        if isinstance(lane_key, str) and lane_key[-1].isdigit():
+            return int(lane_key[-1])
+        return None
+
+    # ------------------------------------------------------------------
+    # reward/cost computation helpers
+    # ------------------------------------------------------------------
+    def _compute_risk_cost(self) -> float:
+        cost = 0.0
+        for i in range(self._num_controlled):
+            veh_i = self._controlled[i]
+            pos_i = np.asarray(veh_i.position)
+            for j in range(i + 1, self._num_controlled):
+                veh_j = self._controlled[j]
+                pos_j = np.asarray(veh_j.position)
+                if np.linalg.norm(pos_i - pos_j) < self.safe_distance:
+                    cost += self.epsilon_distance_cost
+        return cost
+
+    def _compute_collision_cost(self, info: Dict) -> float:
+        if info.get("crashed", False):
+            return self.epsilon_collision_cost
+        for vehicle in self._controlled:
+            if getattr(vehicle, "crashed", False):
+                return self.epsilon_collision_cost
+        return 0.0
+
+    def _compute_reward_components(
+        self,
+        *,
+        current_speeds: np.ndarray,
+        accelerations: np.ndarray,
+        jerk: np.ndarray,
+        dense_cost: float,
+    ) -> RewardBreakdown:
+        step_efficiency = float(np.sum(self.epsilon_v * current_speeds) - self.epsilon_t)
+
+        single_pass_bonus = 0.0
+        passed_flags = [getattr(vehicle, "is_arrived", False) for vehicle in self._controlled]
+        if any(passed_flags):
+            single_pass_bonus = self.epsilon_pass_single * sum(passed_flags)
+        all_pass_bonus = self.epsilon_pass_all if all(passed_flags) else 0.0
+
+        efficiency = step_efficiency + single_pass_bonus + all_pass_bonus
+        comfort = float(np.sum(self.epsilon_a * accelerations + self.epsilon_j * jerk))
+        safety = -dense_cost
+        return RewardBreakdown(efficiency=efficiency, comfort=comfort, safety=safety)
+
+    # ------------------------------------------------------------------
+    # convenience API
+    # ------------------------------------------------------------------
+    @property
+    def num_controlled(self) -> int:
+        return self._num_controlled
+
+    def controlled_vehicle_ids(self) -> Iterable[int]:
+        return range(self._num_controlled)
+
+    def unwrap(self) -> gym.Env:
+        return self.base_env
+

--- a/src/safe_radaim/networks.py
+++ b/src/safe_radaim/networks.py
@@ -1,0 +1,81 @@
+"""Neural network modules used by SafeR-ADAIM."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+import torch.nn as nn
+
+
+class MLP(nn.Module):
+    """A simple fully-connected network with Tanh activations."""
+
+    def __init__(self, input_dim: int, hidden_sizes: Sequence[int], output_dim: int) -> None:
+        super().__init__()
+        layers: list[nn.Module] = []
+        last_dim = input_dim
+        for size in hidden_sizes:
+            layers.append(nn.Linear(last_dim, size))
+            layers.append(nn.Tanh())
+            last_dim = size
+        layers.append(nn.Linear(last_dim, output_dim))
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        return self.model(x)
+
+
+class GaussianPolicy(nn.Module):
+    """Gaussian policy with state-independent log standard deviation."""
+
+    def __init__(self, input_dim: int, hidden_sizes: Sequence[int], action_dim: int) -> None:
+        super().__init__()
+        self.net = MLP(input_dim, hidden_sizes, action_dim)
+        self.log_std = nn.Parameter(torch.zeros(action_dim))
+
+    def forward(self, x: torch.Tensor):  # noqa: D401
+        mean = self.net(x)
+        std = torch.exp(self.log_std).expand_as(mean)
+        return mean, std
+
+    def distribution(self, x: torch.Tensor) -> torch.distributions.Normal:
+        mean, std = self.forward(x)
+        return torch.distributions.Normal(mean, std)
+
+    def sample(self, x: torch.Tensor):
+        dist = self.distribution(x)
+        action = dist.rsample()
+        log_prob = dist.log_prob(action).sum(dim=-1)
+        return action, log_prob, dist
+
+    def log_prob(self, x: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        dist = self.distribution(x)
+        return dist.log_prob(action).sum(dim=-1)
+
+
+class ValueFunction(nn.Module):
+    """State-value estimator."""
+
+    def __init__(self, input_dim: int, hidden_sizes: Sequence[int]) -> None:
+        super().__init__()
+        self.net = MLP(input_dim, hidden_sizes, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        return self.net(x).squeeze(-1)
+
+
+@dataclass
+class SafeRADAIMNetworks:
+    """Container bundling the policy, reward value and cost value networks."""
+
+    policy: GaussianPolicy
+    value_fn: ValueFunction
+    cost_value_fn: ValueFunction
+
+    def to(self, device: torch.device | str) -> "SafeRADAIMNetworks":
+        device = torch.device(device)
+        self.policy.to(device)
+        self.value_fn.to(device)
+        self.cost_value_fn.to(device)
+        return self

--- a/src/safe_radaim/training.py
+++ b/src/safe_radaim/training.py
@@ -1,0 +1,143 @@
+"""High level training loop for SafeR-ADAIM."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from .algorithm import PolicyUpdateInfo, SafeRADAIMAgent
+from .config import SafeRADAIMConfig, SafeRADAIMTrainSettings
+from .env_wrapper import SafeIntersectionEnv
+from .utils import TrajectoryBatch
+
+
+@dataclass
+class TrainingStats:
+    epoch: int
+    total_reward: float
+    total_cost: float
+    policy_info: PolicyUpdateInfo
+    value_losses: Dict[str, float]
+
+
+class SafeRADAIMTrainer:
+    """Coordinate trajectory collection and model updates."""
+
+    def __init__(
+        self,
+        env: SafeIntersectionEnv,
+        agent: SafeRADAIMAgent,
+        config: SafeRADAIMConfig,
+        settings: SafeRADAIMTrainSettings | None = None,
+    ) -> None:
+        self.env = env
+        self.agent = agent
+        self.config = config
+        self.settings = settings or SafeRADAIMTrainSettings(total_epochs=config.epochs)
+
+    def train(self) -> List[TrainingStats]:
+        stats: List[TrainingStats] = []
+        for epoch in range(1, self.settings.total_epochs + 1):
+            batch = self._collect_trajectories()
+            batch = batch.to(self.agent.device)
+            value_losses = self.agent.update_values(batch)
+            policy_info = self.agent.update_policy(batch)
+            total_reward = float(batch.rewards.sum().item())
+            total_cost = float(batch.costs.sum().item())
+            stats.append(
+                TrainingStats(
+                    epoch=epoch,
+                    total_reward=total_reward,
+                    total_cost=total_cost,
+                    policy_info=policy_info,
+                    value_losses=value_losses,
+                )
+            )
+        return stats
+
+    def _collect_trajectories(self) -> TrajectoryBatch:
+        obs_list: List[np.ndarray] = []
+        act_list: List[np.ndarray] = []
+        logp_list: List[float] = []
+        rew_list: List[float] = []
+        cost_list: List[float] = []
+        done_list: List[float] = []
+
+        obs, _ = self.env.reset()
+
+        for step in range(self.config.steps_per_epoch):
+            action, logp = self.agent.act(obs)
+            next_obs, reward, terminated, truncated, info = self.env.step(action)
+            cost = info.get("risk_cost", 0.0)
+
+            obs_list.append(obs)
+            act_list.append(action)
+            logp_list.append(logp)
+            rew_list.append(reward)
+            cost_list.append(cost)
+            done_list.append(float(terminated or truncated))
+
+            obs = next_obs
+            if terminated or truncated:
+                obs, _ = self.env.reset()
+
+        obs_tensor = torch.tensor(np.array(obs_list), dtype=torch.float32)
+        act_tensor = torch.tensor(np.array(act_list), dtype=torch.float32)
+        logp_tensor = torch.tensor(np.array(logp_list), dtype=torch.float32)
+        rew_tensor = torch.tensor(np.array(rew_list), dtype=torch.float32)
+        cost_tensor = torch.tensor(np.array(cost_list), dtype=torch.float32)
+        done_tensor = torch.tensor(np.array(done_list), dtype=torch.float32)
+
+        reward_returns, reward_advantages = self._estimate_advantages(
+            obs_tensor,
+            rew_tensor,
+            done_tensor,
+            self.agent.networks.value_fn,
+            self.config.gamma,
+            self.config.gae_lambda,
+        )
+        cost_returns, cost_advantages = self._estimate_advantages(
+            obs_tensor,
+            cost_tensor,
+            done_tensor,
+            self.agent.networks.cost_value_fn,
+            self.config.cost_gamma,
+            self.config.cost_gae_lambda,
+        )
+
+        return TrajectoryBatch(
+            observations=obs_tensor,
+            actions=act_tensor,
+            rewards=rew_tensor,
+            costs=cost_tensor,
+            dones=done_tensor,
+            log_probs=logp_tensor,
+            reward_advantages=reward_advantages,
+            reward_targets=reward_returns,
+            cost_advantages=cost_advantages,
+            cost_targets=cost_returns,
+        )
+
+    def _estimate_advantages(
+        self,
+        observations: torch.Tensor,
+        rewards: torch.Tensor,
+        dones: torch.Tensor,
+        value_net: nn.Module,
+        gamma: float,
+        lam: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        values = value_net(observations).detach()
+        values = torch.cat([values, torch.zeros(1, device=values.device)])
+        advantages = torch.zeros_like(rewards)
+        gae = 0.0
+        for step in reversed(range(len(rewards))):
+            delta = rewards[step] + gamma * values[step + 1] * (1 - dones[step]) - values[step]
+            gae = delta + gamma * lam * (1 - dones[step]) * gae
+            advantages[step] = gae
+        targets = advantages + values[:-1]
+        return targets.detach(), advantages.detach()
+

--- a/src/safe_radaim/utils.py
+++ b/src/safe_radaim/utils.py
@@ -1,0 +1,88 @@
+"""Utility helpers for SafeR-ADAIM."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+import numpy as np
+import torch
+
+
+def flatten_tensors(tensors: Iterable[torch.Tensor]) -> torch.Tensor:
+    return torch.cat([tensor.reshape(-1) for tensor in tensors])
+
+
+def unflatten_tensors(flat: torch.Tensor, template: Iterable[torch.Tensor]) -> Tuple[torch.Tensor, ...]:
+    outputs = []
+    offset = 0
+    for tensor in template:
+        numel = tensor.numel()
+        outputs.append(flat[offset : offset + numel].view_as(tensor))
+        offset += numel
+    return tuple(outputs)
+
+
+def conjugate_gradients(Avp_fn, b: torch.Tensor, nsteps: int, residual_tol: float = 1e-10) -> torch.Tensor:
+    x = torch.zeros_like(b)
+    r = b.clone()
+    p = b.clone()
+    rdotr = torch.dot(r, r)
+    for _ in range(nsteps):
+        Avp = Avp_fn(p)
+        alpha = rdotr / (torch.dot(p, Avp) + 1e-8)
+        x += alpha * p
+        r -= alpha * Avp
+        new_rdotr = torch.dot(r, r)
+        if new_rdotr < residual_tol:
+            break
+        beta = new_rdotr / (rdotr + 1e-8)
+        p = r + beta * p
+        rdotr = new_rdotr
+    return x
+
+
+def compute_gae(returns: np.ndarray, values: np.ndarray, gamma: float, lam: float) -> Tuple[np.ndarray, np.ndarray]:
+    advantages = np.zeros_like(returns)
+    lastgaelam = 0
+    for t in reversed(range(len(returns))):
+        delta = returns[t] + gamma * values[t + 1] - values[t]
+        advantages[t] = lastgaelam = delta + gamma * lam * lastgaelam
+    targets = advantages + values[:-1]
+    return advantages, targets
+
+
+def explained_variance(y_pred: torch.Tensor, y_true: torch.Tensor) -> float:
+    var_y = torch.var(y_true)
+    if torch.isclose(var_y, torch.tensor(0.0)):
+        return 0.0
+    return 1 - torch.var(y_true - y_pred) / var_y
+
+
+@dataclass
+class TrajectoryBatch:
+    observations: torch.Tensor
+    actions: torch.Tensor
+    rewards: torch.Tensor
+    costs: torch.Tensor
+    dones: torch.Tensor
+    log_probs: torch.Tensor
+    reward_advantages: torch.Tensor
+    reward_targets: torch.Tensor
+    cost_advantages: torch.Tensor
+    cost_targets: torch.Tensor
+
+    def to(self, device: torch.device | str) -> "TrajectoryBatch":
+        device = torch.device(device)
+        return TrajectoryBatch(
+            observations=self.observations.to(device),
+            actions=self.actions.to(device),
+            rewards=self.rewards.to(device),
+            costs=self.costs.to(device),
+            dones=self.dones.to(device),
+            log_probs=self.log_probs.to(device),
+            reward_advantages=self.reward_advantages.to(device),
+            reward_targets=self.reward_targets.to(device),
+            cost_advantages=self.cost_advantages.to(device),
+            cost_targets=self.cost_targets.to(device),
+        )
+

--- a/tasks/paper.yml
+++ b/tasks/paper.yml
@@ -1,0 +1,54 @@
+- id: safe_env_wrapper
+  title: "Wrap intersection environment with SafeR-ADAIM signals"
+  description: |
+    Implement a gym-compatible wrapper that converts the existing
+    IntersectionEnv observations into SafeR-ADAIM state vectors and exposes
+    continuous desired-velocity actions. The wrapper must compute dense
+    distance-based costs, sparse collision costs, and the three reward
+    components defined in the paper.
+  acceptance:
+    - SafeIntersectionEnv returns observations shaped `(num_cars * 5,)` with
+      per-vehicle `[distance, speed, beta_onehot]` ordering.
+    - Actions supplied as an array of desired velocities are executed without
+      errors for at least one rollout of `steps_per_epoch` steps.
+    - `info` from `step()` contains `risk_cost`, `dense_cost`,
+      `collision_cost`, and the reward breakdown.
+  tests:
+    - name: smoke
+      command: "python -m compileall src/safe_radaim/env_wrapper.py"
+
+- id: rscpo_core
+  title: "Implement RSCPO policy update"
+  description: |
+    Implement the SafeR-ADAIM policy update that classifies the current
+    policy into risk regimes (risk-free, moderate, high) and applies the
+    corresponding update rule. The implementation should use conjugate
+    gradients for the Hessian-vector product, solve the dual variables in the
+    moderate-risk case, and perform KL- plus cost-constrained line search.
+  acceptance:
+    - Policy gradients and cost gradients are computed from a trajectory
+      batch and converted into a flat parameter vector.
+    - Risk classification matches the definitions `c_hat < 0`, `F > 0` and
+      `F = δ - c_hat^2/(b^T H^{-1} b)`.
+    - Line search enforces `KL <= max_kl` and `mean_cost <= cost_limit` when
+      a step is accepted.
+  tests:
+    - name: syntax
+      command: "python -m compileall src/safe_radaim/algorithm.py"
+
+- id: training_loop
+  title: "Add SafeR-ADAIM trainer"
+  description: |
+    Build a trainer that gathers on-policy trajectories, computes Generalised
+    Advantage Estimates for both reward and cost, updates value networks, and
+    invokes the policy update each epoch. Provide a CLI entrypoint that runs
+    the training loop and saves the resulting weights.
+  acceptance:
+    - Trainer executes for at least one epoch without raising exceptions.
+    - Saved artifacts `safe_radaim_policy.pt`, `safe_radaim_value.pt`,
+      `safe_radaim_cost_value.pt` appear in `experiments/` after running the
+      CLI with default arguments.
+    - CLI prints epoch-level reward, cost, KL, and risk-case diagnostics.
+  tests:
+    - name: compile
+      command: "python -m compileall src/safe_radaim/training.py safe_radaim_main.py"


### PR DESCRIPTION
## Summary
- document the SafeR-ADAIM paper, architecture mapping, tasks, and migration plan for this repository
- add SafeR-ADAIM environment wrapper, neural networks, RSCPO update logic, and training loop
- provide a CLI entrypoint for training and extend the highway action API with expected-velocity control

## Testing
- python -m compileall src safe_radaim_main.py highwayenv

------
https://chatgpt.com/codex/tasks/task_e_690251265280833295653194725906ff