### PR TITLE
Implement attention-based MADDPG master model

### DIFF
--- a/src/experiment/scenarios.py
+++ b/src/experiment/scenarios.py
@@ -2,7 +2,234 @@
 
 
 
-
+# base_complete_scenarios_3_cars = [
+#
+#     # Scenario 1: All cars turning right
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o1", 0),
+#             (('o1', 'ir1', 0), "o2", 0),
+#             (('o2', 'ir2', 0), "o3", -25),
+#             (('o3', 'ir3', 0), "o0", -35)
+#         ],
+#         "static": [
+#             (('o0', 'ir0', 0), "o1", -15)
+#         ]
+#     },
+#
+#     # Scenario 3: East-west corridor
+#     {
+#         "agents": [
+#             (('o1', 'ir1', 0), "o3", 0),
+#             (('o3', 'ir3', 0), "o1", 0),
+#             (('o1', 'ir1', 0), "o3", -30),
+#             (('o3', 'ir3', 0), "o1", -25),
+#         ],
+#         "static": [
+#             (('o2', 'ir2', 0), "o1", -35)
+#         ]
+#     },
+#     # Scenario 4: Complex multi-direction
+#     {
+#         "agents": [
+#             (('o2', 'ir2', 0), "o0", 0),
+#             (('o1', 'ir1', 0), "o2", 0),
+#             (('o0', 'ir0', 0), "o3", -45),
+#             (('o1', 'ir1', 0), "o2", -30),
+#         ],
+#         "static": [
+#
+#             (('o2', 'ir2', 0), "o0", -20)
+#         ]
+#     },
+#     # Scenario 5: Same origin dispersal
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o0', 'ir0', 0), "o1", 20),
+#             (('o0', 'ir0', 0), "o2", -50),
+#             (('o1', 'ir1', 0), "o3", -30),
+#         ],
+#         "static": [
+#
+#             (('o2', 'ir2', 0), "o0", -25)
+#         ]
+#     },
+#     # Scenario 6: Convergence to same destination
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o1', 'ir1', 0), "o2", 0),
+#             (('o3', 'ir3', 0), "o2", -40),
+#             (('o2', 'ir2', 0), "o1", -30),
+#         ],
+#         "static": [
+#
+#             (('o0', 'ir0', 0), "o3", -50)
+#         ]
+#     },
+#     # Scenario 7: Minimum conflict scenario
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o2', 'ir2', 0), "o0", 0),
+#             (('o1', 'ir1', 0), "o3", -40),
+#             (('o3', 'ir3', 0), "o1", -35),
+#         ],
+#         "static": [
+#             (('o0', 'ir0', 0), "o1", -60)
+#         ]
+#     },
+#     # Scenario 8: Rush hour challenge
+#     {
+#         "agents": [
+#             (('o3', 'ir3', 0), "o1", 0),
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o1', 'ir1', 0), "o3", -20),
+#             (('o2', 'ir2', 0), "o0", -15),
+#         ],
+#         "static": [
+#             (('o3', 'ir3', 0), "o2", -45)
+#         ]
+#     },
+#     # Scenario 13: Complex intersection
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o1", 0),
+#             (('o3', 'ir3', 0), "o0", 0),
+#             (('o1', 'ir1', 0), "o2", -25),
+#             (('o2', 'ir2', 0), "o3", -30),
+#         ],
+#         "static": [
+#             (('o0', 'ir0', 0), "o3", -60)
+#         ]
+#     },
+#     # Scenario 14: Parallel lanes
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o0', 'ir0', 0), "o2", -30),
+#             (('o2', 'ir2', 0), "o0", -60),
+#             (('o1', 'ir1', 0), "o3", -55),
+#         ],
+#         "static": [
+#             (('o3', 'ir3', 0), "o1", -65)
+#         ]
+#     },
+#     # Scenario 15: Cross traffic
+#     {
+#         "agents": [
+#             (('o1', 'ir1', 0), "o3", 0),
+#             (('o2', 'ir2', 0), "o0", 0),
+#             (('o0', 'ir0', 0), "o2", -30),
+#             (('o3', 'ir3', 0), "o1", -25),
+#         ],
+#         "static": [
+#             (('o1', 'ir1', 0), "o0", -50)
+#         ]
+#     },
+#     # Scenario 16: Left turn conflict
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o3", 0),
+#             (('o1', 'ir1', 0), "o0", 0),
+#             (('o2', 'ir2', 0), "o1", -35),
+#             (('o3', 'ir3', 0), "o2", -40),
+#         ],
+#         "static": [
+#             (('o0', 'ir0', 0), "o1", -55)
+#         ]
+#     },
+#     # Scenario 17: Right turn priority
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o1", 0),
+#             (('o2', 'ir2', 0), "o3", 0),
+#             (('o1', 'ir1', 0), "o2", -50),
+#             (('o3', 'ir3', 0), "o0", -55),
+#         ],
+#         "static": [
+#             (('o0', 'ir0', 0), "o2", -55)
+#         ]
+#     },
+#     # Scenario 18: Staggered timing
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o1', 'ir1', 0), "o3", -40),
+#             (('o2', 'ir2', 0), "o0", -50),
+#             (('o3', 'ir3', 0), "o1", -35),
+#         ],
+#         "static": [
+#
+#             (('o0', 'ir0', 0), "o1", -20)
+#         ]
+#     },
+#     # Scenario 20: Opposite directions
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o2', 'ir2', 0), "o0", 0),
+#             (('o1', 'ir1', 0), "o3", -30),
+#             (('o3', 'ir3', 0), "o1", -35),
+#         ],
+#         "static": [
+#
+#             (('o0', 'ir0', 0), "o1", -10)
+#         ]
+#     },
+#     # Scenario 21: Diagonal crossing
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o3", 0),
+#             (('o1', 'ir1', 0), "o2", 0),
+#             (('o2', 'ir2', 0), "o1", -25),
+#             (('o3', 'ir3', 0), "o0", -30),
+#         ],
+#         "static": [
+#
+#             (('o0', 'ir0', 0), "o2", -35)
+#         ]
+#     },
+#     # Scenario 22: Sequential turns
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o1", 0),
+#             (('o1', 'ir1', 0), "o2", 0),
+#             (('o2', 'ir2', 0), "o3", -50),
+#             (('o3', 'ir3', 0), "o0", -55),
+#         ],
+#         "static": [
+#
+#             (('o0', 'ir0', 0), "o3", -65)
+#         ]
+#     },
+#     # Scenario 23: Wide spacing
+#     {
+#         "agents": [
+#             (('o0', 'ir0', 0), "o2", 0),
+#             (('o1', 'ir1', 0), "o3", 50),
+#             (('o2', 'ir2', 0), "o0", -60),
+#             (('o3', 'ir3', 0), "o1", -45),
+#         ],
+#         "static": [
+#
+#             (('o0', 'ir0', 0), "o1", -75)
+#         ]
+#     },
+#     # Scenario 24: Mixed patterns
+#     {
+#         "agents": [
+#             (('o2', 'ir2', 0), "o3", 0),
+#             (('o3', 'ir3', 0), "o2", 15),
+#             (('o0', 'ir0', 0), "o1", -30),
+#             (('o1', 'ir1', 0), "o0", -35),
+#         ],
+#         "static": [
+#             (('o2', 'ir2', 0), "o0", -50)
+#         ]
+#     }
+# ]
 
 base_complete_scenarios_3_cars = [
     # Scenario 0: Heavy north-south flow
@@ -247,308 +474,305 @@ base_complete_scenarios_3_cars = [
     }
 ]
 
-
-
-
-base_complete_scenarios_2_cars = [
-            # Scenario 0: Heavy north-south flow
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o1', 'ir1', 0), "o3", 0)  # Agent 2: East to West
-                ],
-                "static": [
-                    (('o0', 'ir0', 0), "o2", -50),  # Static: North to South (behind)
-                    (('o2', 'ir2', 0), "o0", -35),  # Static: South to North
-                    (('o0', 'ir0', 0), "o1", -70)  # Static: North to East
-                ]
-            },
-            # Scenario 1: All cars turning right
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
-                    (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o3", -25),  # Static: South to West (right)
-                    (('o3', 'ir3', 0), "o0", -35),  # Static: West to North (right)
-                    (('o0', 'ir0', 0), "o1", -15)  # Static: North to East (right)
-                ]
-            },
-            # Scenario 2: Crossing patterns
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left)
-                    (('o2', 'ir2', 0), "o1", 0)  # Agent 2: South to East (left)
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o0", -20),  # Static: East to North (left)
-                    (('o3', 'ir3', 0), "o2", -30),  # Static: West to South (left)
-                    (('o0', 'ir0', 0), "o2", -40)  # Static: North to South (straight)
-                ]
-            },
-            # Scenario 3: East-west corridor
-            {
-                "agents": [
-                    (('o1', 'ir1', 0), "o3", 0),  # Agent 1: East to West
-                    (('o3', 'ir3', 0), "o1", 0)  # Agent 2: West to East
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o3", -30),  # Static: East to West (behind)
-                    (('o3', 'ir3', 0), "o1", -25),  # Static: West to East (behind)
-                    (('o2', 'ir2', 0), "o1", -35)  # Static: South to East (left)
-                ]
-            },
-            # Scenario 4: Complex multi-direction
-            {
-                "agents": [
-                    (('o2', 'ir2', 0), "o0", 0),  # Agent 1: South to North
-                    (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
-                ],
-                "static": [
-                    (('o0', 'ir0', 0), "o3", -45),  # Static: North to West (left, far behind)
-                    (('o1', 'ir1', 0), "o2", -30),  # Static: East to South (right)
-                    (('o2', 'ir2', 0), "o0", -20)  # Static: South to North (straight)
-                ]
-            },
-            # Scenario 5: Same origin dispersal
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o0', 'ir0', 0), "o1", 20)  # Agent 2: North to East (offset forward)
-                ],
-                "static": [
-                    (('o0', 'ir0', 0), "o2", -50),  # Static: North to South (behind)
-                    (('o1', 'ir1', 0), "o3", -30),  # Static: East to West
-                    (('o2', 'ir2', 0), "o0", -25)  # Static: South to North
-                ]
-            },
-            # Scenario 6: Convergence to same destination
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
-                ],
-                "static": [
-                    (('o3', 'ir3', 0), "o2", -40),  # Static: West to South (converge)
-                    (('o2', 'ir2', 0), "o1", -30),  # Static: South to East
-                    (('o0', 'ir0', 0), "o3", -50)  # Static: North to West
-                ]
-            },
-            # Scenario 7: Minimum conflict scenario
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South (straight)
-                    (('o2', 'ir2', 0), "o0", 0)  # Agent 2: South to North (straight)
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o3", -40),  # Static: East to West (parallel)
-                    (('o3', 'ir3', 0), "o1", -35),  # Static: West to East (parallel)
-                    (('o0', 'ir0', 0), "o1", -60)  # Static: North to East (turn)
-                ]
-            },
-            # Scenario 8: Rush hour challenge
-            {
-                "agents": [
-                    (('o3', 'ir3', 0), "o1", 0),  # Agent 1: West to East
-                    (('o0', 'ir0', 0), "o2", 0)  # Agent 2: North to South
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o3", -20),  # Static: East to West (opposite)
-                    (('o2', 'ir2', 0), "o0", -15),  # Static: South to North (opposite)
-                    (('o3', 'ir3', 0), "o2", -45)  # Static: West to South (turn)
-                ]
-            },
-            # # Scenario 9: Mixed speed challenge
-            # {
-            #     "agents": [
-            #         (('o1', 'ir1', 0), "o0", 0),  # Agent 1: East to North (left)
-            #         (('o2', 'ir2', 0), "o3", 0)  # Agent 2: South to West (left)
-            #     ],
-            #     "static": [
-            #         (('o0', 'ir0', 0), "o1", -25),  # Static: North to East (right)
-            #         (('o3', 'ir3', 0), "o2", -30),  # Static: West to South (right)
-            #         (('o1', 'ir1', 0), "o2", -50)  # Static: East to South (right)
-            #     ]
-            # },
-            # Scenario 10: Emergency scenario
-            # {
-            #     "agents": [
-            #         (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left turn)
-            #         (('o1', 'ir1', 0), "o0", 30)  # Agent 2: East to North (ahead)
-            #     ],
-            #     "static": [
-            #         (('o2', 'ir2', 0), "o1", -35),  # Static: South to East
-            #         (('o3', 'ir3', 0), "o0", -40),  # Static: West to North
-            #         (('o0', 'ir0', 0), "o2", -55)  # Static: North to South
-            #     ]
-            # },
-            # Scenario 11: T-junction behavior
-            # {
-            #     "agents": [
-            #         (('o2', 'ir2', 0), "o1", 0),  # Agent 1: South to East (left)
-            #         (('o2', 'ir2', 0), "o3", 20)  # Agent 2: South to West (right, ahead)
-            #     ],
-            #     "static": [
-            #         (('o1', 'ir1', 0), "o0", -30),  # Static: East to North
-            #         (('o3', 'ir3', 0), "o2", -25),  # Static: West to South
-            #         (('o0', 'ir0', 0), "o1", -45)  # Static: North to East
-            #     ]
-            # },
-            # Scenario 12: Highway merge simulation
-            # {
-            #     "agents": [
-            #         (('o3', 'ir3', 0), "o2", 0),  # Agent 1: West to South (left)
-            #         (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
-            #     ],
-            #     "static": [
-            #         (('o0', 'ir0', 0), "o2", -20),  # Static: North to South (merge point)
-            #         (('o2', 'ir2', 0), "o0", -35),  # Static: South to North
-            #         (('o3', 'ir3', 0), "o1", -50)  # Static: West to East
-            #     ]
-            # },
-            # Scenario 13: Complex intersection
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
-                    (('o3', 'ir3', 0), "o0", 0)  # Agent 2: West to North (right)
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o2", -25),  # Static: East to South (right)
-                    (('o2', 'ir2', 0), "o3", -30),  # Static: South to West (right)
-                    (('o0', 'ir0', 0), "o3", -60)  # Static: North to West (left)
-                ]
-            },
-            # Scenario 14: Parallel lanes
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o0', 'ir0', 0), "o2", -30)  # Agent 2: North to South (behind)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o0", -60),  # Static: South to North (parallel)
-                    (('o1', 'ir1', 0), "o3", -55),  # Static: East to West (crossing)
-                    (('o3', 'ir3', 0), "o1", -65)  # Static: West to East (crossing)
-                ]
-            },
-            # Scenario 15: Cross traffic
-            {
-                "agents": [
-                    (('o1', 'ir1', 0), "o3", 0),  # Agent 1: East to West
-                    (('o2', 'ir2', 0), "o0", 0)  # Agent 2: South to North
-                ],
-                "static": [
-                    (('o0', 'ir0', 0), "o2", -30),  # Static: North to South (crossing)
-                    (('o3', 'ir3', 0), "o1", -25),  # Static: West to East (opposite)
-                    (('o1', 'ir1', 0), "o0", -50)  # Static: East to North (turn)
-                ]
-            },
-            # Scenario 16: Left turn conflict
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left)
-                    (('o1', 'ir1', 0), "o0", 0)  # Agent 2: East to North (left)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o1", -35),  # Static: South to East (left)
-                    (('o3', 'ir3', 0), "o2", -40),  # Static: West to South (left)
-                    (('o0', 'ir0', 0), "o1", -55)  # Static: North to East (right)
-                ]
-            },
-            # Scenario 17: Right turn priority
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
-                    (('o2', 'ir2', 0), "o3", 0)  # Agent 2: South to West (right)
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o2", -50),  # Static: East to South (right)
-                    (('o3', 'ir3', 0), "o0", -55),  # Static: West to North (right)
-                    (('o0', 'ir0', 0), "o2", -55)  # Static: North to South (straight)
-                ]
-            },
-            # Scenario 18: Staggered timing
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o1', 'ir1', 0), "o3", -40)  # Agent 2: East to West (behind)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o0", -50),  # Static: South to North (behind)
-                    (('o3', 'ir3', 0), "o1", -35),  # Static: West to East (behind)
-                    (('o0', 'ir0', 0), "o1", -20)  # Static: North to East (behind)
-                ]
-            },
-            # # Scenario 19: Dense traffic
-            # {
-            #     "agents": [
-            #         (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-            #         (('o1', 'ir1', 0), "o2", -10)  # Agent 2: East to South (close behind)
-            #     ],
-            #     "static": [
-            #         (('o3', 'ir3', 0), "o2", -20),  # Static: West to South (converge)
-            #         (('o2', 'ir2', 0), "o0", -25),  # Static: South to North (opposite)
-            #         (('o0', 'ir0', 0), "o3", -30)  # Static: North to West (turn)
-            #     ]
-            # },
-            # # Scenario 20: Opposite directions
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o2', 'ir2', 0), "o0", 0)  # Agent 2: South to North
-                ],
-                "static": [
-                    (('o1', 'ir1', 0), "o3", -30),  # Static: East to West (parallel)
-                    (('o3', 'ir3', 0), "o1", -35),  # Static: West to East (parallel)
-                    (('o0', 'ir0', 0), "o1", -10)  # Static: North to East (turn)
-                ]
-            },
-            # Scenario 21: Diagonal crossing
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left)
-                    (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o1", -25),  # Static: South to East (left)
-                    (('o3', 'ir3', 0), "o0", -30),  # Static: West to North (right)
-                    (('o0', 'ir0', 0), "o2", -35)  # Static: North to South (straight)
-                ]
-            },
-            # Scenario 22: Sequential turns
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
-                    (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o3", -50),  # Static: South to West (right)
-                    (('o3', 'ir3', 0), "o0", -55),  # Static: West to North (right)
-                    (('o0', 'ir0', 0), "o3", -65)  # Static: North to West (left)
-                ]
-            },
-            # Scenario 23: Wide spacing
-            {
-                "agents": [
-                    (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
-                    (('o1', 'ir1', 0), "o3", 50)  # Agent 2: East to West (far ahead)
-                ],
-                "static": [
-                    (('o2', 'ir2', 0), "o0", -60),  # Static: South to North (far behind)
-                    (('o3', 'ir3', 0), "o1", -45),  # Static: West to East (behind)
-                    (('o0', 'ir0', 0), "o1", -75)  # Static: North to East (far behind)
-                ]
-            },
-            # Scenario 24: Mixed patterns
-            {
-                "agents": [
-                    (('o2', 'ir2', 0), "o3", 0),  # Agent 1: South to West (right)
-                    (('o3', 'ir3', 0), "o2", 15)  # Agent 2: West to South (left, ahead)
-                ],
-                "static": [
-                    (('o0', 'ir0', 0), "o1", -30),  # Static: North to East (right)
-                    (('o1', 'ir1', 0), "o0", -35),  # Static: East to North (left)
-                    (('o2', 'ir2', 0), "o0", -50)  # Static: South to North (straight)
-                ]
-            }
-        ]
+# base_complete_scenarios_2_cars = [
+#             # Scenario 0: Heavy north-south flow
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o1', 'ir1', 0), "o3", 0)  # Agent 2: East to West
+#                 ],
+#                 "static": [
+#                     (('o0', 'ir0', 0), "o2", -50),  # Static: North to South (behind)
+#                     (('o2', 'ir2', 0), "o0", -35),  # Static: South to North
+#                     (('o0', 'ir0', 0), "o1", -70)  # Static: North to East
+#                 ]
+#             },
+#             # Scenario 1: All cars turning right
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
+#                     (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o3", -25),  # Static: South to West (right)
+#                     (('o3', 'ir3', 0), "o0", -35),  # Static: West to North (right)
+#                     (('o0', 'ir0', 0), "o1", -15)  # Static: North to East (right)
+#                 ]
+#             },
+#             # Scenario 2: Crossing patterns
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left)
+#                     (('o2', 'ir2', 0), "o1", 0)  # Agent 2: South to East (left)
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o0", -20),  # Static: East to North (left)
+#                     (('o3', 'ir3', 0), "o2", -30),  # Static: West to South (left)
+#                     (('o0', 'ir0', 0), "o2", -40)  # Static: North to South (straight)
+#                 ]
+#             },
+#             # Scenario 3: East-west corridor
+#             {
+#                 "agents": [
+#                     (('o1', 'ir1', 0), "o3", 0),  # Agent 1: East to West
+#                     (('o3', 'ir3', 0), "o1", 0)  # Agent 2: West to East
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o3", -30),  # Static: East to West (behind)
+#                     (('o3', 'ir3', 0), "o1", -25),  # Static: West to East (behind)
+#                     (('o2', 'ir2', 0), "o1", -35)  # Static: South to East (left)
+#                 ]
+#             },
+#             # Scenario 4: Complex multi-direction
+#             {
+#                 "agents": [
+#                     (('o2', 'ir2', 0), "o0", 0),  # Agent 1: South to North
+#                     (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
+#                 ],
+#                 "static": [
+#                     (('o0', 'ir0', 0), "o3", -45),  # Static: North to West (left, far behind)
+#                     (('o1', 'ir1', 0), "o2", -30),  # Static: East to South (right)
+#                     (('o2', 'ir2', 0), "o0", -20)  # Static: South to North (straight)
+#                 ]
+#             },
+#             # Scenario 5: Same origin dispersal
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o0', 'ir0', 0), "o1", 20)  # Agent 2: North to East (offset forward)
+#                 ],
+#                 "static": [
+#                     (('o0', 'ir0', 0), "o2", -50),  # Static: North to South (behind)
+#                     (('o1', 'ir1', 0), "o3", -30),  # Static: East to West
+#                     (('o2', 'ir2', 0), "o0", -25)  # Static: South to North
+#                 ]
+#             },
+#             # Scenario 6: Convergence to same destination
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
+#                 ],
+#                 "static": [
+#                     (('o3', 'ir3', 0), "o2", -40),  # Static: West to South (converge)
+#                     (('o2', 'ir2', 0), "o1", -30),  # Static: South to East
+#                     (('o0', 'ir0', 0), "o3", -50)  # Static: North to West
+#                 ]
+#             },
+#             # Scenario 7: Minimum conflict scenario
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South (straight)
+#                     (('o2', 'ir2', 0), "o0", 0)  # Agent 2: South to North (straight)
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o3", -40),  # Static: East to West (parallel)
+#                     (('o3', 'ir3', 0), "o1", -35),  # Static: West to East (parallel)
+#                     (('o0', 'ir0', 0), "o1", -60)  # Static: North to East (turn)
+#                 ]
+#             },
+#             # Scenario 8: Rush hour challenge
+#             {
+#                 "agents": [
+#                     (('o3', 'ir3', 0), "o1", 0),  # Agent 1: West to East
+#                     (('o0', 'ir0', 0), "o2", 0)  # Agent 2: North to South
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o3", -20),  # Static: East to West (opposite)
+#                     (('o2', 'ir2', 0), "o0", -15),  # Static: South to North (opposite)
+#                     (('o3', 'ir3', 0), "o2", -45)  # Static: West to South (turn)
+#                 ]
+#             },
+#             # # Scenario 9: Mixed speed challenge
+#             # {
+#             #     "agents": [
+#             #         (('o1', 'ir1', 0), "o0", 0),  # Agent 1: East to North (left)
+#             #         (('o2', 'ir2', 0), "o3", 0)  # Agent 2: South to West (left)
+#             #     ],
+#             #     "static": [
+#             #         (('o0', 'ir0', 0), "o1", -25),  # Static: North to East (right)
+#             #         (('o3', 'ir3', 0), "o2", -30),  # Static: West to South (right)
+#             #         (('o1', 'ir1', 0), "o2", -50)  # Static: East to South (right)
+#             #     ]
+#             # },
+#             # Scenario 10: Emergency scenario
+#             # {
+#             #     "agents": [
+#             #         (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left turn)
+#             #         (('o1', 'ir1', 0), "o0", 30)  # Agent 2: East to North (ahead)
+#             #     ],
+#             #     "static": [
+#             #         (('o2', 'ir2', 0), "o1", -35),  # Static: South to East
+#             #         (('o3', 'ir3', 0), "o0", -40),  # Static: West to North
+#             #         (('o0', 'ir0', 0), "o2", -55)  # Static: North to South
+#             #     ]
+#             # },
+#             # Scenario 11: T-junction behavior
+#             # {
+#             #     "agents": [
+#             #         (('o2', 'ir2', 0), "o1", 0),  # Agent 1: South to East (left)
+#             #         (('o2', 'ir2', 0), "o3", 20)  # Agent 2: South to West (right, ahead)
+#             #     ],
+#             #     "static": [
+#             #         (('o1', 'ir1', 0), "o0", -30),  # Static: East to North
+#             #         (('o3', 'ir3', 0), "o2", -25),  # Static: West to South
+#             #         (('o0', 'ir0', 0), "o1", -45)  # Static: North to East
+#             #     ]
+#             # },
+#             # Scenario 12: Highway merge simulation
+#             # {
+#             #     "agents": [
+#             #         (('o3', 'ir3', 0), "o2", 0),  # Agent 1: West to South (left)
+#             #         (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
+#             #     ],
+#             #     "static": [
+#             #         (('o0', 'ir0', 0), "o2", -20),  # Static: North to South (merge point)
+#             #         (('o2', 'ir2', 0), "o0", -35),  # Static: South to North
+#             #         (('o3', 'ir3', 0), "o1", -50)  # Static: West to East
+#             #     ]
+#             # },
+#             # Scenario 13: Complex intersection
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
+#                     (('o3', 'ir3', 0), "o0", 0)  # Agent 2: West to North (right)
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o2", -25),  # Static: East to South (right)
+#                     (('o2', 'ir2', 0), "o3", -30),  # Static: South to West (right)
+#                     (('o0', 'ir0', 0), "o3", -60)  # Static: North to West (left)
+#                 ]
+#             },
+#             # Scenario 14: Parallel lanes
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o0', 'ir0', 0), "o2", -30)  # Agent 2: North to South (behind)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o0", -60),  # Static: South to North (parallel)
+#                     (('o1', 'ir1', 0), "o3", -55),  # Static: East to West (crossing)
+#                     (('o3', 'ir3', 0), "o1", -65)  # Static: West to East (crossing)
+#                 ]
+#             },
+#             # Scenario 15: Cross traffic
+#             {
+#                 "agents": [
+#                     (('o1', 'ir1', 0), "o3", 0),  # Agent 1: East to West
+#                     (('o2', 'ir2', 0), "o0", 0)  # Agent 2: South to North
+#                 ],
+#                 "static": [
+#                     (('o0', 'ir0', 0), "o2", -30),  # Static: North to South (crossing)
+#                     (('o3', 'ir3', 0), "o1", -25),  # Static: West to East (opposite)
+#                     (('o1', 'ir1', 0), "o0", -50)  # Static: East to North (turn)
+#                 ]
+#             },
+#             # Scenario 16: Left turn conflict
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left)
+#                     (('o1', 'ir1', 0), "o0", 0)  # Agent 2: East to North (left)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o1", -35),  # Static: South to East (left)
+#                     (('o3', 'ir3', 0), "o2", -40),  # Static: West to South (left)
+#                     (('o0', 'ir0', 0), "o1", -55)  # Static: North to East (right)
+#                 ]
+#             },
+#             # Scenario 17: Right turn priority
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
+#                     (('o2', 'ir2', 0), "o3", 0)  # Agent 2: South to West (right)
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o2", -50),  # Static: East to South (right)
+#                     (('o3', 'ir3', 0), "o0", -55),  # Static: West to North (right)
+#                     (('o0', 'ir0', 0), "o2", -55)  # Static: North to South (straight)
+#                 ]
+#             },
+#             # Scenario 18: Staggered timing
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o1', 'ir1', 0), "o3", -40)  # Agent 2: East to West (behind)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o0", -50),  # Static: South to North (behind)
+#                     (('o3', 'ir3', 0), "o1", -35),  # Static: West to East (behind)
+#                     (('o0', 'ir0', 0), "o1", -20)  # Static: North to East (behind)
+#                 ]
+#             },
+#             # # Scenario 19: Dense traffic
+#             # {
+#             #     "agents": [
+#             #         (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#             #         (('o1', 'ir1', 0), "o2", -10)  # Agent 2: East to South (close behind)
+#             #     ],
+#             #     "static": [
+#             #         (('o3', 'ir3', 0), "o2", -20),  # Static: West to South (converge)
+#             #         (('o2', 'ir2', 0), "o0", -25),  # Static: South to North (opposite)
+#             #         (('o0', 'ir0', 0), "o3", -30)  # Static: North to West (turn)
+#             #     ]
+#             # },
+#             # # Scenario 20: Opposite directions
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o2', 'ir2', 0), "o0", 0)  # Agent 2: South to North
+#                 ],
+#                 "static": [
+#                     (('o1', 'ir1', 0), "o3", -30),  # Static: East to West (parallel)
+#                     (('o3', 'ir3', 0), "o1", -35),  # Static: West to East (parallel)
+#                     (('o0', 'ir0', 0), "o1", -10)  # Static: North to East (turn)
+#                 ]
+#             },
+#             # Scenario 21: Diagonal crossing
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o3", 0),  # Agent 1: North to West (left)
+#                     (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o1", -25),  # Static: South to East (left)
+#                     (('o3', 'ir3', 0), "o0", -30),  # Static: West to North (right)
+#                     (('o0', 'ir0', 0), "o2", -35)  # Static: North to South (straight)
+#                 ]
+#             },
+#             # Scenario 22: Sequential turns
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o1", 0),  # Agent 1: North to East (right)
+#                     (('o1', 'ir1', 0), "o2", 0)  # Agent 2: East to South (right)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o3", -50),  # Static: South to West (right)
+#                     (('o3', 'ir3', 0), "o0", -55),  # Static: West to North (right)
+#                     (('o0', 'ir0', 0), "o3", -65)  # Static: North to West (left)
+#                 ]
+#             },
+#             # Scenario 23: Wide spacing
+#             {
+#                 "agents": [
+#                     (('o0', 'ir0', 0), "o2", 0),  # Agent 1: North to South
+#                     (('o1', 'ir1', 0), "o3", 50)  # Agent 2: East to West (far ahead)
+#                 ],
+#                 "static": [
+#                     (('o2', 'ir2', 0), "o0", -60),  # Static: South to North (far behind)
+#                     (('o3', 'ir3', 0), "o1", -45),  # Static: West to East (behind)
+#                     (('o0', 'ir0', 0), "o1", -75)  # Static: North to East (far behind)
+#                 ]
+#             },
+#             # Scenario 24: Mixed patterns
+#             {
+#                 "agents": [
+#                     (('o2', 'ir2', 0), "o3", 0),  # Agent 1: South to West (right)
+#                     (('o3', 'ir3', 0), "o2", 15)  # Agent 2: West to South (left, ahead)
+#                 ],
+#                 "static": [
+#                     (('o0', 'ir0', 0), "o1", -30),  # Static: North to East (right)
+#                     (('o1', 'ir1', 0), "o0", -35),  # Static: East to North (left)
+#                     (('o2', 'ir2', 0), "o0", -50)  # Static: South to North (straight)
+#                 ]
+#             }
+#         ]

--- a/src/experiment/scenarios_config.py
+++ b/src/experiment/scenarios_config.py
@@ -127,14 +127,68 @@ CONFIG_EXP5_3_controlled_cars = {
     }
 }
 
+CONFIG_EXP5_4_controlled_cars = {
+
+    "controlled_cars": {
+        "car1": {
+            "start_lane": Experiment.SOUTH_TO_NORTH,
+            "destination": Experiment.OUTER_NORTH,
+            "speed": Experiment.THROTTLE_SLOW,
+            "init_location": {
+                "longitudinal": Experiment.LONGITUDINAL,
+                "lateral": Experiment.LATERAL
+            },
+            "color": (0, 204, 0)  # Green car
+        },
+        "car2": {
+            "start_lane": Experiment.EAST_TO_WEST,
+            "destination": Experiment.OUTER_WEST,
+            "speed": Experiment.THROTTLE_SLOW,
+            "init_location": {
+                "longitudinal": Experiment.LONGITUDINAL + 20,
+                "lateral": Experiment.LATERAL
+            },
+            "color": (0, 0, 204)  # car
+        },
+        "car3": {
+            "start_lane": Experiment.EAST_TO_WEST,
+            "destination": Experiment.OUTER_WEST,
+            "speed": Experiment.THROTTLE_SLOW,
+            "init_location": {
+                "longitudinal": Experiment.LONGITUDINAL - 20,
+                "lateral": Experiment.LATERAL
+            },
+            "color": (204, 0, 0)
+        },
+        "car4": {
+            "start_lane": Experiment.NORTH_TO_SOUTH,
+            "destination": Experiment.OUTER_WEST,
+            "speed": Experiment.THROTTLE_SLOW,
+            "init_location": {
+                "longitudinal": Experiment.LONGITUDINAL - 40,
+                "lateral": Experiment.LATERAL
+            },
+            "color": (0, 0, 50)
+        }
+    },
+    "static_cars": {
+        "car5": {
+            "start_lane": Experiment.NORTH_TO_SOUTH,
+            "destination": Experiment.OUTER_WEST,
+            "speed": Experiment.FIXED_THROTTLE,
+            "init_location": {
+                "longitudinal": Experiment.LONGITUDINAL - 10,
+                "lateral": Experiment.LATERAL
+            },
+            "color": (0, 50, 0)  # Green car
+        }
+    }
+}
 
 current_experiment = CONFIG_EXP5_3_controlled_cars
 
-
 full_env_config_exp5 = create_full_environment_config(current_experiment)
-
 
 for _ in current_experiment["controlled_cars"]:
     after_is_arrived_flags.append(False)
 
-# TODO: make sure it works

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -3,7 +3,7 @@ import random
 import gymnasium as gym
 import numpy as np
 import torch
-from gymnasium import spaces
+from gym import spaces as gym_spaces
 import warnings
 warnings.filterwarnings("ignore")
 
@@ -28,11 +28,17 @@ class Driver(gym.Env):
 
         # Define action and observation spaces
         # Highway environment uses discrete actions
-        self.action_space = spaces.Discrete(experiment.ACTION_SPACE_SIZE)
+        # Stable-Baselines3 (v1.6) expects classic gym space instances for
+        # compatibility checks.  When we rely solely on gymnasium's spaces,
+        # SB3 raises an assertion error because the objects are not instances
+        # of ``gym.spaces.Space``.  To keep the environment gymnasium-based
+        # while staying compatible with SB3 we instantiate equivalent spaces
+        # from the legacy ``gym`` package.
+        self.action_space = gym_spaces.Discrete(experiment.ACTION_SPACE_SIZE)
 
         # Observation space: combined car state and embedding
         # Car state is 4-dimensional (x, y, vx, vy) and embedding is 4-dimensional
-        self.observation_space = spaces.Box(
+        self.observation_space = gym_spaces.Box(
             low=-np.inf,
             high=np.inf,
             shape=(experiment.STATE_INPUT_SIZE,),  # Default is 8 (4 car state + 4 embedding)

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -5,6 +5,9 @@ import numpy as np
 import torch
 from gym import spaces as gym_spaces
 import warnings
+
+from gymnasium import spaces
+
 warnings.filterwarnings("ignore")
 
 class Driver(gym.Env):
@@ -34,7 +37,7 @@ class Driver(gym.Env):
         # of ``gym.spaces.Space``.  To keep the environment gymnasium-based
         # while staying compatible with SB3 we instantiate equivalent spaces
         # from the legacy ``gym`` package.
-        self.action_space = gym_spaces.Discrete(experiment.ACTION_SPACE_SIZE)
+        self.action_space = spaces.Discrete(experiment.ACTION_SPACE_SIZE)
 
         # Observation space: combined car state and embedding
         # Car state is 4-dimensional (x, y, vx, vy) and embedding is 4-dimensional
@@ -42,20 +45,11 @@ class Driver(gym.Env):
         # underlying observation does not have hard physical limits, we can use
         # the maximum finite value representable in float32 to approximate
         # unbounded ranges while satisfying the API contract.
-        obs_low = np.full(
-            experiment.STATE_INPUT_SIZE,
-            -np.finfo(np.float32).max,
-            dtype=np.float32,
-        )
-        obs_high = np.full(
-            experiment.STATE_INPUT_SIZE,
-            np.finfo(np.float32).max,
-            dtype=np.float32,
-        )
-        self.observation_space = gym_spaces.Box(
-            low=obs_low,
-            high=obs_high,
-            dtype=np.float32,
+        self.observation_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(experiment.STATE_INPUT_SIZE,),  # Default is 8 (4 car state + 4 embedding)
+            dtype=np.float32
         )
 
         # Track episode information

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -38,11 +38,24 @@ class Driver(gym.Env):
 
         # Observation space: combined car state and embedding
         # Car state is 4-dimensional (x, y, vx, vy) and embedding is 4-dimensional
+        # Stable-Baselines3 requires finite bounds for Box spaces.  While the
+        # underlying observation does not have hard physical limits, we can use
+        # the maximum finite value representable in float32 to approximate
+        # unbounded ranges while satisfying the API contract.
+        obs_low = np.full(
+            experiment.STATE_INPUT_SIZE,
+            -np.finfo(np.float32).max,
+            dtype=np.float32,
+        )
+        obs_high = np.full(
+            experiment.STATE_INPUT_SIZE,
+            np.finfo(np.float32).max,
+            dtype=np.float32,
+        )
         self.observation_space = gym_spaces.Box(
-            low=-np.inf,
-            high=np.inf,
-            shape=(experiment.STATE_INPUT_SIZE,),  # Default is 8 (4 car state + 4 embedding)
-            dtype=np.float32
+            low=obs_low,
+            high=obs_high,
+            dtype=np.float32,
         )
 
         # Track episode information

--- a/src/model/master_model.py
+++ b/src/model/master_model.py
@@ -45,21 +45,33 @@ class AttentionPolicyNetwork(nn.Module):
         self.num_agents = num_agents
         self.action_dim = action_dim
 
+        # Based on Section IV-B and Table II of the paper:
+
+        # Encoder block - Two linear layers with ReLU, layer size 64x64
         self.entity_encoder = nn.Sequential(
-            nn.Linear(per_agent_obs_dim, hidden_dim),
+            nn.Linear(per_agent_obs_dim, 64),
             nn.ReLU(),
-            nn.Linear(hidden_dim, hidden_dim),
-            nn.ReLU(),
+            nn.Linear(64, 64),
         )
 
+        # Attention block - 2 heads, feature size (embed_dim) = 128
         self.attention = nn.MultiheadAttention(
-            embed_dim=hidden_dim, num_heads=num_heads, batch_first=True
+            embed_dim=128,
+            num_heads=2,
+            batch_first=True
         )
 
+        # Note: You need a projection layer to go from encoder output (64) to attention input (128)
+        self.encoder_to_attention = nn.Linear(64, 128)
+
+        # Decoder block - Two linear layers with ReLU, layer size 64x64
+        # Output is action_dim, with Tanh activation
         self.decoder = nn.Sequential(
-            nn.Linear(hidden_dim, hidden_dim),
+            nn.Linear(128, 64),  # First map from attention output (128) to 64
             nn.ReLU(),
-            nn.Linear(hidden_dim, action_dim),
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Linear(64, action_dim),
             nn.Tanh(),
         )
 

--- a/src/model/master_model.py
+++ b/src/model/master_model.py
@@ -1,237 +1,441 @@
 # Code and comments only in English.
 
+from __future__ import annotations
+
 import os
-import gymnasium as gym
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
 import numpy as np
 import torch
-from gymnasium import spaces
-from stable_baselines3 import PPO
-from stable_baselines3.common.buffers import RolloutBuffer
-from experiment.experiment_config import Experiment
-from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
 import torch.nn as nn
-
-###############################################
-# MASTER MODEL - PURE SB3 PPO
-###############################################
-class SimpleResNetExtractor(BaseFeaturesExtractor):
-    def __init__(self, observation_space, features_dim=128):
-        super().__init__(observation_space, features_dim)
-
-        input_dim = observation_space.shape[0]
-
-        # Input layer
-        self.input_layer = nn.Linear(input_dim, 128)
-
-        # ResNet blocks
-        self.res_block1 = nn.Sequential(
-            nn.Linear(128, 128),
-            nn.ReLU(),
-            nn.Linear(128, 128)
-        )
-
-        self.res_block2 = nn.Sequential(
-            nn.Linear(128, 128),
-            nn.ReLU(),
-            nn.Linear(128, 128)
-        )
-
-        # Output
-        self.output_layer = nn.Linear(128, features_dim)
-        self.relu = nn.ReLU()
-
-    def forward(self, observations):
-        x = self.relu(self.input_layer(observations))
-
-        # ResNet skip connections
-        residual1 = x
-        x = self.res_block1(x) + residual1  # Skip connection
-        x = self.relu(x)
-
-        residual2 = x
-        x = self.res_block2(x) + residual2  # Skip connection
-        x = self.relu(x)
-
-        return self.output_layer(x)
+import torch.nn.functional as F
 
 
-###############################################
-# Minimal real Gymnasium Env (replaces the dummy)
-###############################################
-class _MasterEnv(gym.Env):
-    """
-    Minimal working environment so PPO can actually collect rollouts.
-    Replace the synthetic dynamics/reward with your simulator when ready.
-    """
-    metadata = {"render_modes": []}
+def _to_numpy(data: torch.Tensor | np.ndarray | list | tuple) -> np.ndarray:
+    """Utility that converts inputs to float32 numpy arrays."""
+    if isinstance(data, np.ndarray):
+        return data.astype(np.float32)
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().numpy().astype(np.float32)
+    return np.asarray(data, dtype=np.float32)
 
-    def __init__(self, obs_dim: int, emb_dim: int, max_steps: int = 128, seed: int | None = None):
+
+def _flatten_state(state: torch.Tensor | np.ndarray) -> np.ndarray:
+    """Flatten arbitrary shaped observations into (obs_dim,) arrays."""
+    array = _to_numpy(state)
+    if array.ndim > 1:
+        return array.reshape(-1)
+    return array
+
+
+class AttentionPolicyNetwork(nn.Module):
+    """Attention based policy network used by every agent actor."""
+
+    def __init__(
+        self,
+        per_agent_obs_dim: int,
+        action_dim: int,
+        num_agents: int,
+        hidden_dim: int = 128,
+        num_heads: int = 4,
+    ) -> None:
         super().__init__()
-        self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=(obs_dim,), dtype=np.float32)
-        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(emb_dim,), dtype=np.float32)
+        self.per_agent_obs_dim = per_agent_obs_dim
+        self.num_agents = num_agents
+        self.action_dim = action_dim
 
-        self._obs_dim = obs_dim
-        self._emb_dim = emb_dim
-        self._max_steps = max_steps
-        self._rng = np.random.default_rng(seed)
-        self._state = np.zeros(self._obs_dim, dtype=np.float32)
-        self._steps = 0
+        self.entity_encoder = nn.Sequential(
+            nn.Linear(per_agent_obs_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+        )
 
-    def reset(self, seed: int | None = None, options=None):
-        if seed is not None:
-            self._rng = np.random.default_rng(seed)
-        self._steps = 0
-        # synthetic initial state
-        self._state = self._rng.standard_normal(self._obs_dim).astype(np.float32)
-        return self._state.copy(), {}
+        self.attention = nn.MultiheadAttention(
+            embed_dim=hidden_dim, num_heads=num_heads, batch_first=True
+        )
 
-    def step(self, action):
-        self._steps += 1
-        action = np.asarray(action, dtype=np.float32).reshape(self._emb_dim)
+        self.decoder = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+            nn.Tanh(),
+        )
 
-        # synthetic reward: penalize large embeddings (placeholder)
-        reward = -float(np.linalg.norm(action))
+        self._last_attention_weights: Optional[torch.Tensor] = None
 
-        # simple controllable dynamics: blend action (padded) into state + noise
-        pad = np.zeros(self._obs_dim, dtype=np.float32)
-        pad[: self._emb_dim] = action
-        noise = self._rng.standard_normal(self._obs_dim).astype(np.float32) * 0.05
-        self._state = (0.9 * self._state + 0.1 * pad + noise).astype(np.float32)
+    def forward(self, observations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return per-agent continuous actions and the attention weights."""
 
-        terminated = False
-        truncated = self._steps >= self._max_steps
-        return self._state.copy(), reward, terminated, truncated, {}
+        batch_size = observations.shape[0]
+        reshaped = observations.view(batch_size, self.num_agents, self.per_agent_obs_dim)
+        encoded = self.entity_encoder(reshaped)
+
+        # Each agent attends to every other agent and itself
+        attention_context, attention_weights = self.attention(encoded, encoded, encoded, need_weights=True)
+        self._last_attention_weights = attention_weights.detach()
+
+        actions = self.decoder(attention_context)
+        return actions, attention_weights
+
+    @property
+    def last_attention_weights(self) -> Optional[torch.Tensor]:
+        return self._last_attention_weights
+
+
+class CentralCriticNetwork(nn.Module):
+    """Centralized critic that evaluates the joint observation-action pair."""
+
+    def __init__(self, observation_dim: int, action_dim: int, hidden_dim: int = 256) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(observation_dim + action_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, observations: torch.Tensor, actions: torch.Tensor) -> torch.Tensor:
+        obs_flat = observations.view(observations.size(0), -1)
+        actions_flat = actions.view(actions.size(0), -1)
+        critic_input = torch.cat([obs_flat, actions_flat], dim=-1)
+        return self.net(critic_input)
+
+
+@dataclass
+class ReplayBatch:
+    observations: torch.Tensor
+    actions: torch.Tensor
+    rewards: torch.Tensor
+    next_observations: torch.Tensor
+    dones: torch.Tensor
+
+
+class ReplayBuffer:
+    """Replay buffer tailored for MADDPG style updates."""
+
+    def __init__(
+        self,
+        capacity: int,
+        observation_dim: int,
+        action_dim: int,
+        num_agents: int,
+    ) -> None:
+        self.capacity = capacity
+        self.observation_dim = observation_dim
+        self.action_dim = action_dim
+        self.num_agents = num_agents
+
+        self.observations = np.zeros((capacity, observation_dim), dtype=np.float32)
+        self.actions = np.zeros((capacity, num_agents, action_dim), dtype=np.float32)
+        self.rewards = np.zeros((capacity, 1), dtype=np.float32)
+        self.next_observations = np.zeros((capacity, observation_dim), dtype=np.float32)
+        self.dones = np.zeros((capacity, 1), dtype=np.float32)
+
+        self._size = 0
+        self._pos = 0
+
+    def __len__(self) -> int:
+        return self._size
+
+    def add(
+        self,
+        observation: np.ndarray,
+        action: np.ndarray,
+        reward: float,
+        next_observation: np.ndarray,
+        done: bool,
+    ) -> None:
+        self.observations[self._pos] = observation
+        self.actions[self._pos] = action
+        self.rewards[self._pos] = reward
+        self.next_observations[self._pos] = next_observation
+        self.dones[self._pos] = float(done)
+
+        self._pos = (self._pos + 1) % self.capacity
+        self._size = min(self._size + 1, self.capacity)
+
+    def sample(self, batch_size: int, device: torch.device) -> ReplayBatch:
+        indices = np.random.choice(self._size, size=batch_size, replace=False)
+        obs = torch.tensor(self.observations[indices], dtype=torch.float32, device=device)
+        acts = torch.tensor(self.actions[indices], dtype=torch.float32, device=device)
+        rews = torch.tensor(self.rewards[indices], dtype=torch.float32, device=device)
+        next_obs = torch.tensor(self.next_observations[indices], dtype=torch.float32, device=device)
+        dones = torch.tensor(self.dones[indices], dtype=torch.float32, device=device)
+        return ReplayBatch(obs, acts, rews, next_obs, dones)
+
+    def clear(self) -> None:
+        self._size = 0
+        self._pos = 0
 
 
 class MasterModel:
-    """
-    PURE SB3 PPO - NO CUSTOM ANYTHING
-    """
+    """MADDPG style master model with attention based actors."""
 
-    def __init__(self, embedding_size=4, experiment=None, observation_dim=None, **kwargs):
-        # Accept all possible arguments for compatibility
+    def __init__(
+        self,
+        observation_dim: int,
+        embedding_dim: int,
+        num_agents: Optional[int] = None,
+        *,
+        per_agent_obs_dim: Optional[int] = None,
+        attention_hidden_dim: int = 128,
+        attention_heads: int = 4,
+        critic_hidden_dim: int = 256,
+        replay_capacity: int = 50_000,
+        batch_size: int = 128,
+        gamma: float = 0.99,
+        tau: float = 0.01,
+        actor_lr: float = 1e-4,
+        critic_lr: float = 1e-3,
+        device: Optional[str] = None,
+    ) -> None:
+        if num_agents is None:
+            inferred_agents = observation_dim // 4
+            num_agents = max(1, inferred_agents)
+        if per_agent_obs_dim is None:
+            per_agent_obs_dim = observation_dim // num_agents
 
-        if "embedding_dim" in kwargs and kwargs["embedding_dim"] is not None:
-                   embedding_size = int(kwargs.pop("embedding_dim"))
-        self.embedding_size = embedding_size
-        self.experiment = experiment
-        self.is_frozen = False
+        self.observation_dim = observation_dim
+        self.embedding_dim = embedding_dim
+        self.num_agents = num_agents
+        self.per_agent_obs_dim = per_agent_obs_dim
 
-        # Calculate observation dimension
-        if observation_dim is not None:
-            self.observation_dim = observation_dim
-        elif experiment is not None:
-            max_cars = experiment.CARS_AMOUNT if hasattr(experiment, 'CARS_AMOUNT') else 5
-            self.observation_dim = max_cars * 4
-        else:
-            self.observation_dim = 20  # Default 5 cars * 4 features
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.gamma = gamma
+        self.tau = tau
+        self.batch_size = batch_size
+        self.training_enabled = True
 
-        # Create a real minimal environment (replaces the dummy)
-        env = _MasterEnv(obs_dim=self.observation_dim, emb_dim=embedding_size)
+        self.actor = AttentionPolicyNetwork(
+            per_agent_obs_dim=per_agent_obs_dim,
+            action_dim=embedding_dim,
+            num_agents=num_agents,
+            hidden_dim=attention_hidden_dim,
+            num_heads=attention_heads,
+        ).to(self.device)
+        self.critic = CentralCriticNetwork(
+            observation_dim=observation_dim,
+            action_dim=embedding_dim * num_agents,
+            hidden_dim=critic_hidden_dim,
+        ).to(self.device)
 
-        # Get n_steps safely
-        try:
-            n_steps = experiment.N_STEPS if experiment and hasattr(experiment, 'N_STEPS') else 64
-        except:
-            n_steps = 64
+        self.actor_target = AttentionPolicyNetwork(
+            per_agent_obs_dim=per_agent_obs_dim,
+            action_dim=embedding_dim,
+            num_agents=num_agents,
+            hidden_dim=attention_hidden_dim,
+            num_heads=attention_heads,
+        ).to(self.device)
+        self.critic_target = CentralCriticNetwork(
+            observation_dim=observation_dim,
+            action_dim=embedding_dim * num_agents,
+            hidden_dim=critic_hidden_dim,
+        ).to(self.device)
 
-        # PURE SB3 PPO - NOTHING CUSTOM
-        self.model = PPO(
-            "MlpPolicy",
-            env,
-            learning_rate=1e-4,
-            n_steps=n_steps,
-            batch_size=128,
-            gamma=0.99,
-            gae_lambda=0.95,
-            clip_range=0.2,
-            ent_coef=0.01,
-            vf_coef=0.5,
-            policy_kwargs=dict(
-                features_extractor_class=SimpleResNetExtractor,
-                features_extractor_kwargs=dict(features_dim=128),
-                net_arch=[128,256,128]
-            ),
-            verbose=1,
-            device="cpu"
-        )
-
-        # Rollout buffer for compatibility (kept as-is, just uses env spaces)
-        self.rollout_buffer = RolloutBuffer(
-            buffer_size=n_steps,
-            observation_space=env.observation_space,
-            action_space=env.action_space,
-            gamma=0.99,
-            gae_lambda=0.95,
-            n_envs=1
-        )
-
-    def unfreeze(self):
-        """Enable training for master network"""
-        self.is_frozen = False
-        for param in self.model.policy.parameters():
-            param.requires_grad = True
-        self.model.policy.set_training_mode(True)
-        print("[PureSB3Master] UNFROZEN - Training enabled")
-
-    def freeze(self):
-        """Disable training for master network"""
-        self.is_frozen = True
-        for param in self.model.policy.parameters():
+        self.actor_target.load_state_dict(self.actor.state_dict())
+        self.critic_target.load_state_dict(self.critic.state_dict())
+        self.actor_target.eval()
+        self.critic_target.eval()
+        for param in self.actor_target.parameters():
             param.requires_grad = False
-        self.model.policy.set_training_mode(False)
-        print("[PureSB3Master] FROZEN - Training disabled")
+        for param in self.critic_target.parameters():
+            param.requires_grad = False
 
-    def get_proto_action(self, state_tensor):
-        """
-        Get embedding using standard SB3 predict with proper tensor handling
-        """
-        # Convert to the format SB3 expects
-        if isinstance(state_tensor, np.ndarray) and state_tensor.shape == (5, 4):
-            obs = state_tensor.flatten()
-        else:
-            obs = np.array(state_tensor).flatten()
+        self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=actor_lr)
+        self.critic_optimizer = torch.optim.Adam(self.critic.parameters(), lr=critic_lr)
 
-        # Ensure correct size
-        if len(obs) < self.observation_dim:
-            padded_obs = np.zeros(self.observation_dim)
-            padded_obs[:len(obs)] = obs
-            obs = padded_obs
-        elif len(obs) > self.observation_dim:
-            obs = obs[:self.observation_dim]
+        self.replay_buffer = ReplayBuffer(
+            capacity=replay_capacity,
+            observation_dim=observation_dim,
+            action_dim=embedding_dim,
+            num_agents=num_agents,
+        )
 
-        # Convert to tensor for policy evaluation
-        obs_tensor = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
+        self.noise_std = 0.1
+        self.logger = None
+        self._last_joint_action: Optional[np.ndarray] = None
+        self._last_state: Optional[np.ndarray] = None
+
+    # ------------------------------------------------------------------
+    # Public API used by the training loop
+    # ------------------------------------------------------------------
+    def unfreeze(self) -> None:
+        self.training_enabled = True
+        for param in self.actor.parameters():
+            param.requires_grad = True
+        for param in self.critic.parameters():
+            param.requires_grad = True
+        self.actor.train(True)
+        self.critic.train(True)
+
+    def freeze(self) -> None:
+        self.training_enabled = False
+        for param in self.actor.parameters():
+            param.requires_grad = False
+        for param in self.critic.parameters():
+            param.requires_grad = False
+        self.actor.eval()
+        self.critic.eval()
+
+    def set_logger(self, logger) -> None:  # pragma: no cover - simple setter
+        self.logger = logger
+
+    def set_noise_std(self, noise_std: float) -> None:
+        self.noise_std = max(0.0, float(noise_std))
+
+    def get_proto_action(
+        self, state_tensor: torch.Tensor | np.ndarray
+    ) -> Tuple[np.ndarray, torch.Tensor, torch.Tensor]:
+        state_np = _flatten_state(state_tensor)
+        if state_np.shape[0] < self.observation_dim:
+            padded = np.zeros(self.observation_dim, dtype=np.float32)
+            padded[: state_np.shape[0]] = state_np
+            state_np = padded
+        elif state_np.shape[0] > self.observation_dim:
+            state_np = state_np[: self.observation_dim]
+        self._last_state = state_np
+
+        state_batch = torch.tensor(state_np, dtype=torch.float32, device=self.device).view(1, -1)
+        with torch.no_grad():
+            actions, _ = self.actor(state_batch)
+        actions = actions.cpu().numpy()[0]
+
+        if self.training_enabled and self.noise_std > 0.0:
+            actions = actions + np.random.normal(0.0, self.noise_std, size=actions.shape)
+            actions = np.clip(actions, -1.0, 1.0)
+
+        self._last_joint_action = actions.astype(np.float32)
+
+        # Return the ego agent embedding (index 0) for compatibility
+        embedding = self._last_joint_action[0]
+        dummy_tensor = torch.zeros(1, dtype=torch.float32)
+        return embedding, dummy_tensor, dummy_tensor
+
+    def store_transition(
+        self,
+        state: np.ndarray,
+        actions: np.ndarray,
+        reward: float,
+        next_state: np.ndarray,
+        done: bool,
+    ) -> None:
+        state_flat = _flatten_state(state)
+        if state_flat.shape[0] < self.observation_dim:
+            padded_state = np.zeros(self.observation_dim, dtype=np.float32)
+            padded_state[: state_flat.shape[0]] = state_flat
+            state_flat = padded_state
+        elif state_flat.shape[0] > self.observation_dim:
+            state_flat = state_flat[: self.observation_dim]
+        next_state_flat = _flatten_state(next_state)
+        if next_state_flat.shape[0] < self.observation_dim:
+            padded_next = np.zeros(self.observation_dim, dtype=np.float32)
+            padded_next[: next_state_flat.shape[0]] = next_state_flat
+            next_state_flat = padded_next
+        elif next_state_flat.shape[0] > self.observation_dim:
+            next_state_flat = next_state_flat[: self.observation_dim]
+        actions_arr = _to_numpy(actions).reshape(self.num_agents, self.embedding_dim)
+        self.replay_buffer.add(state_flat, actions_arr, float(reward), next_state_flat, bool(done))
+
+    def train_step(self) -> Optional[Tuple[float, float]]:
+        if not self.training_enabled:
+            return None
+        if len(self.replay_buffer) < self.batch_size:
+            return None
+
+        batch = self.replay_buffer.sample(self.batch_size, self.device)
 
         with torch.no_grad():
-            # Use the policy directly to get action, value, and log_prob
-            action, value, log_prob = self.model.policy.forward(obs_tensor)
+            next_actions, _ = self.actor_target(batch.next_observations)
+            target_q = self.critic_target(batch.next_observations, next_actions)
+            target_values = batch.rewards + self.gamma * (1.0 - batch.dones) * target_q
 
-            # Convert to numpy for the action (embedding)
-            action_np, _ = self.model.predict(obs, deterministic=False)
-            action_np = np.asarray(action_np).reshape(-1)
+        current_q = self.critic(batch.observations, batch.actions)
+        critic_loss = F.mse_loss(current_q, target_values)
 
-            value_tensor = self.model.policy.predict_values(obs_tensor)
-            dist = self.model.policy.get_distribution(obs_tensor)
-            log_prob_tensor = dist.log_prob(torch.tensor(action_np, dtype=torch.float32).unsqueeze(0))
+        self.critic_optimizer.zero_grad()
+        critic_loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.critic.parameters(), max_norm=1.0)
+        self.critic_optimizer.step()
 
-        return action_np, value_tensor, log_prob_tensor
+        actions_pred, _ = self.actor(batch.observations)
+        actor_loss = -self.critic(batch.observations, actions_pred).mean()
 
-    def set_logger(self, logger):
-        """Set logger for master network"""
-        self.model.set_logger(logger)
+        self.actor_optimizer.zero_grad()
+        actor_loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.actor.parameters(), max_norm=1.0)
+        self.actor_optimizer.step()
 
-    def save(self, path):
-        """Save master network"""
-        self.model.save(path)
-        custom_params = {
-            "embedding_size": self.embedding_size,
+        self._soft_update(self.actor_target, self.actor)
+        self._soft_update(self.critic_target, self.critic)
+
+        return actor_loss.item(), critic_loss.item()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def save(self, path: str) -> None:
+        payload = {
+            "actor": self.actor.state_dict(),
+            "critic": self.critic.state_dict(),
+            "actor_target": self.actor_target.state_dict(),
+            "critic_target": self.critic_target.state_dict(),
+            "actor_opt": self.actor_optimizer.state_dict(),
+            "critic_opt": self.critic_optimizer.state_dict(),
+            "config": {
+                "observation_dim": self.observation_dim,
+                "embedding_dim": self.embedding_dim,
+                "num_agents": self.num_agents,
+                "per_agent_obs_dim": self.per_agent_obs_dim,
+                "gamma": self.gamma,
+                "tau": self.tau,
+                "batch_size": self.batch_size,
+                "noise_std": self.noise_std,
+            },
         }
-        torch.save(custom_params, f"{path}_custom_params.pt")
+        torch.save(payload, path)
 
-    def load(self, path):
-        """Load master network"""
-        self.model = PPO.load(path)
-        if os.path.exists(f"{path}_custom_params.pt"):
-            custom_params = torch.load(f"{path}_custom_params.pt")
-            self.embedding_size = custom_params["embedding_size"]
+    def load(self, path: str) -> None:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"No master model found at {path}")
+        checkpoint = torch.load(path, map_location=self.device)
+        self.actor.load_state_dict(checkpoint["actor"])
+        self.critic.load_state_dict(checkpoint["critic"])
+        self.actor_target.load_state_dict(checkpoint["actor_target"])
+        self.critic_target.load_state_dict(checkpoint["critic_target"])
+        self.actor_optimizer.load_state_dict(checkpoint["actor_opt"])
+        self.critic_optimizer.load_state_dict(checkpoint["critic_opt"])
+
+        config = checkpoint.get("config", {})
+        self.gamma = config.get("gamma", self.gamma)
+        self.tau = config.get("tau", self.tau)
+        self.batch_size = config.get("batch_size", self.batch_size)
+        self.noise_std = config.get("noise_std", self.noise_std)
+
+    # ------------------------------------------------------------------
+    # Convenience properties
+    # ------------------------------------------------------------------
+    @property
+    def last_joint_action(self) -> Optional[np.ndarray]:
+        return self._last_joint_action
+
+    @property
+    def last_state(self) -> Optional[np.ndarray]:
+        return self._last_state
+
+    @property
+    def last_attention_weights(self) -> Optional[np.ndarray]:
+        weights = self.actor.last_attention_weights
+        if weights is None:
+            return None
+        return weights.detach().cpu().numpy()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _soft_update(self, target: nn.Module, source: nn.Module) -> None:
+        for target_param, param in zip(target.parameters(), source.parameters()):
+            target_param.data.copy_(target_param.data * (1.0 - self.tau) + param.data * self.tau)
+

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -31,7 +31,7 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         all_drivers_states = env.env.current_state
 
         # Master embedding (and its value/log_prob if needed)
-        embedding, value, log_prob = master_model.get_proto_action(ensure_tensor(all_drivers_states))
+        embedding, _, _ = master_model.get_proto_action(ensure_tensor(all_drivers_states))
 
         # Agent actions
         actions = Driver.get_action(
@@ -85,27 +85,21 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
             crashed = True
 
         # flags for buffers
-        episode_start = (steps_counter == 1)
         done_flag = bool(done or truncated)
 
-        # Add to rollout buffers
-        all_drivers_states = all_drivers_states.reshape(-1) if isinstance(all_drivers_states, np.ndarray) and len(all_drivers_states.shape) == 2 else all_drivers_states
+        # Store experience for the master model
+        if master_model.last_joint_action is not None:
+            next_state_snapshot = env.env.current_state
+            master_model.store_transition(
+                all_drivers_states,
+                master_model.last_joint_action,
+                reward,
+                next_state_snapshot,
+                done_flag,
+            )
 
-        if train_both:
-            for car_index in range(len(project_globals.after_is_arrived_flags)):
-                if not project_globals.after_is_arrived_flags[car_index]:
-                    rollout_buffers[car_index].add(
-                        agent_obs_list[car_index],
-                        cars_action_arrays[car_index],
-                        reward,
-                        done_flag,
-                        cars_values[car_index],
-                        cars_log_probas[car_index]
-                    )
-            master_model.rollout_buffer.add(all_drivers_states, embedding, reward, done_flag, value, log_prob)
-        elif training_master:
-            master_model.rollout_buffer.add(all_drivers_states, embedding, reward, done_flag, value, log_prob)
-        else:
+        # Add to agent rollout buffers
+        if train_both or not training_master:
             for car_index in range(len(project_globals.after_is_arrived_flags)):
                 if not project_globals.after_is_arrived_flags[car_index]:
                     rollout_buffers[car_index].add(
@@ -199,7 +193,6 @@ def process_episode(episode_idx, total_steps, env, master_model, agent_model, ex
     Returns: (reward, actions, steps, crashed)
     """
     logger.info("Episode %d", episode_idx)
-    master_model.rollout_buffer.reset()
     reset_all_buffers()  # reset all buffers (for each Driver)
 
     # TODO: Create an assert here to see that they are reset propely

--- a/src/training/general_utils.py
+++ b/src/training/general_utils.py
@@ -175,38 +175,37 @@ def close_everything(env, agent_logger, master_logger):
 
 
 def monitor_episode_results(master_model, agent_model):
-    """Prints minimal statistics about the rollout buffers"""
-    master_buffer_size = master_model.rollout_buffer.pos
+    """Print minimal statistics about the replay/rollout buffers."""
+    master_buffer_size = len(master_model.replay_buffer)
     agent_buffer_size = agent_model.rollout_buffer.pos
 
-    print(f"Current buffer sizes - Master: {master_buffer_size}, Agent: {agent_buffer_size}")
+    print(
+        f"Current buffer sizes - Master replay: {master_buffer_size}, Agent rollout: {agent_buffer_size}"
+    )
 
-    if master_buffer_size > 0 and hasattr(master_model.rollout_buffer, 'rewards'):
-        rewards = master_model.rollout_buffer.rewards[:master_buffer_size]
-        print(f"Episode rewards - Min: {rewards.min():.2f}, Max: {rewards.max():.2f}, Avg: {rewards.mean():.2f}")
+    if master_buffer_size > 0:
+        rewards = master_model.replay_buffer.rewards[:master_buffer_size]
+        print(
+            f"Episode rewards - Min: {rewards.min():.2f}, Max: {rewards.max():.2f}, Avg: {rewards.mean():.2f}"
+        )
 
 
 def monitor_rollout_buffers(master_model, agent_model):
-    """Prints statistics about the rollout buffers for debugging"""
-    print("\n--- Rollout Buffer Statistics ---")
+    """Print statistics about the replay and rollout buffers for debugging."""
+    print("\n--- Buffer Statistics ---")
 
-    # Master buffer stats
-    print("Master rollout buffer:")
-    print(f"  Buffer size: {master_model.rollout_buffer.buffer_size}")
-    print(f"  Current position: {master_model.rollout_buffer.pos}")
-    print(f"  Is full: {master_model.rollout_buffer.full}")
-
-    if hasattr(master_model.rollout_buffer, 'observations') and master_model.rollout_buffer.observations is not None:
-        print(f"  Observations shape: {master_model.rollout_buffer.observations.shape}")
-
-    if hasattr(master_model.rollout_buffer, 'actions') and master_model.rollout_buffer.actions is not None:
-        print(f"  Actions shape: {master_model.rollout_buffer.actions.shape}")
-
-    if hasattr(master_model.rollout_buffer, 'rewards') and master_model.rollout_buffer.rewards is not None:
-        rewards = master_model.rollout_buffer.rewards[:master_model.rollout_buffer.pos]
-        if len(rewards) > 0:
-            print(f"  Rewards stats: min={rewards.min():.4f}, max={rewards.max():.4f}, mean={rewards.mean():.4f}")
-            print(f"  Rewards: {rewards}")
+    print("Master replay buffer:")
+    print(f"  Capacity: {master_model.replay_buffer.capacity}")
+    print(f"  Current size: {len(master_model.replay_buffer)}")
+    print(f"  Observation dim: {master_model.replay_buffer.observation_dim}")
+    print(
+        f"  Action shape: ({master_model.replay_buffer.num_agents}, {master_model.replay_buffer.action_dim})"
+    )
+    if len(master_model.replay_buffer) > 0:
+        rewards = master_model.replay_buffer.rewards[: len(master_model.replay_buffer)]
+        print(
+            f"  Rewards stats: min={rewards.min():.4f}, max={rewards.max():.4f}, mean={rewards.mean():.4f}"
+        )
 
     # Agent buffer stats
     print("\nAgent rollout buffer:")

--- a/src/training/training_handler.py
+++ b/src/training/training_handler.py
@@ -31,9 +31,20 @@ def training_loop(experiment, env, agent_model, master_model):
 
     # Add rollout buffer per controlled car
     for _ in env.env.config["controlled_cars"]:
+        obs_low = np.full(
+            (experiment.STATE_INPUT_SIZE,),
+            -np.finfo(np.float32).max,
+            dtype=np.float32,
+        )
+        obs_high = np.full(
+            (experiment.STATE_INPUT_SIZE,),
+            np.finfo(np.float32).max,
+            dtype=np.float32,
+        )
+
         new_rollout_buffer_instance = RolloutBuffer(
             buffer_size=experiment.N_STEPS,
-            observation_space=spaces.Box(low=-np.inf, high=np.inf, shape=(experiment.STATE_INPUT_SIZE,)),
+            observation_space=spaces.Box(low=obs_low, high=obs_high, dtype=np.float32),
             action_space=spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32),
             gamma=0.99,
             gae_lambda=0.95,

--- a/src/training/training_loop_utils.py
+++ b/src/training/training_loop_utils.py
@@ -71,69 +71,23 @@ def record_losses(
 
 
 def train_master_and_reset_buffer(master_model, full_obs):
-    """Trains the master model and resets its buffer - Returns loss values"""
-    policy_loss_val = value_loss_val = total_loss_val = None
+    """Train the MADDPG master model once."""
+    _ = full_obs  # kept for compatibility with previous signature
     try:
-        with torch.no_grad():
-            last_master_tensor = ensure_tensor(full_obs)
-            last_value = master_model.model.policy.predict_values(last_master_tensor)
-        if master_model.rollout_buffer.pos == 0:
-            print("Master model: No data to train on")
+        losses = master_model.train_step()
+        if losses is None:
+            print("Master model: Not enough data for training")
             return None
-        master_model.rollout_buffer.compute_returns_and_advantage(last_value, np.array([True]))
-        orig_get = master_model.rollout_buffer.get
-
-        def modified_get(batch_size):
-            if not master_model.rollout_buffer.full:
-                orig_full = master_model.rollout_buffer.full
-                master_model.rollout_buffer.full = True
-                try:
-                    indices = np.arange(master_model.rollout_buffer.pos)
-                    if len(indices) > 0:
-                        return master_model.rollout_buffer._get_samples(indices)
-                    else:
-                        return None
-                finally:
-                    master_model.rollout_buffer.full = orig_full
-            else:
-                return next(orig_get(batch_size))
-
-        try:
-            master_model.rollout_buffer.get = modified_get
-            rollout_data = master_model.rollout_buffer.get(batch_size=None)
-            if rollout_data is not None:
-                steps_trained = len(rollout_data.observations)
-                print(f"Master model trained on {steps_trained} steps")
-                observations_tensor = torch.FloatTensor(rollout_data.observations)
-                actions_tensor = torch.FloatTensor(rollout_data.actions)
-                policy = master_model.model.policy
-                optimizer = policy.optimizer
-                values, log_probs, entropy = policy.evaluate_actions(observations_tensor, actions_tensor)
-                value_loss = ((values - torch.FloatTensor(rollout_data.returns)) ** 2).mean()
-                policy_loss = -log_probs.mean()
-                entropy_loss = -entropy.mean()
-                loss = policy_loss + 0.5 * value_loss + 0.01 * entropy_loss
-                optimizer.zero_grad()
-                loss.backward()
-                torch.nn.utils.clip_grad_norm_(policy.parameters(), 0.5)
-                optimizer.step()
-                policy_loss_val = policy_loss.item()
-                value_loss_val = value_loss.item()
-                total_loss_val = loss.item()
-                #print(
-                #    f"Master loss - Policy: {policy_loss_val:.4f}, Value: {value_loss_val:.4f}, Total: {total_loss_val:.4f}")
-            else:
-                print("Master model: No valid data for training")
-        finally:
-            master_model.rollout_buffer.get = orig_get
-    except Exception as e:
-        print(f"Error during master training: {str(e)}")
+        actor_loss, critic_loss = losses
+        total_loss = actor_loss + critic_loss
+        print(
+            f"Master model update - Actor loss: {actor_loss:.4f}, Critic loss: {critic_loss:.4f}"
+        )
+        return [actor_loss, critic_loss, total_loss]
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"Error during master training: {exc}")
         traceback.print_exc()
-    master_model.rollout_buffer.reset()
-    print("Master buffer reset")
-    if policy_loss_val is not None:
-        return [policy_loss_val, value_loss_val, total_loss_val]
-    return None
+        return None
 
 
 


### PR DESCRIPTION
## Summary
- replace the PPO-based master network with an attention-driven MADDPG implementation that uses centralized training and decentralized execution
- add replay buffer management and attention-aware action selection for the master while keeping agent integrations intact
- update training utilities and diagnostics to work with the MADDPG workflow and replay buffers

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_690b1f7c1bf083328d026fe95d64c91a