### PR TITLE
Refactor agent to emit joint multi-vehicle actions

### DIFF
--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -43,7 +43,7 @@ class Driver(gym.Env):
 
         # Observation space: concatenated per-vehicle observation (4-dim state +
         # shared embedding) for all controlled vehicles.
-        per_vehicle_obs_dim = experiment.STATE_INPUT_SIZE
+        per_vehicle_obs_dim = experiment.AGENT_STATE_SIZE
         observation_dim = self.num_cars * per_vehicle_obs_dim
         self.observation_space = spaces.Box(
             low=-np.inf,
@@ -155,7 +155,8 @@ class Driver(gym.Env):
                     car_state = current_state[car_index]
                 car_state = np.asarray(car_state, dtype=np.float32)
 
-            agent_observations.append(np.concatenate((car_state, embedding_array)))
+            # agent_observations.append(np.concatenate((car_state, embedding_array)))
+            agent_observations.append(car_state)
 
         stacked_obs = np.stack(agent_observations, axis=0).astype(np.float32)
         flat_obs = stacked_obs.reshape(-1)
@@ -196,7 +197,8 @@ class Driver(gym.Env):
                     car_state = next_state[car_index]
                 car_state = np.asarray(car_state, dtype=np.float32)
 
-            agent_next_observations.append(np.concatenate((car_state, embedding_array)))
+            # agent_next_observations.append(np.concatenate((car_state, embedding_array)))
+            agent_next_observations.append(car_state)
 
         stacked_next_obs = np.stack(agent_next_observations, axis=0).astype(np.float32)
         flat_next_obs = stacked_next_obs.reshape(-1)

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -29,26 +29,26 @@ class Driver(gym.Env):
         # Load environment configuration
         self.config = experiment.CONFIG if hasattr(experiment, 'CONFIG') else None
 
-        # Define action and observation spaces
-        # Highway environment uses discrete actions
-        # Stable-Baselines3 (v1.6) expects classic gym space instances for
-        # compatibility checks.  When we rely solely on gymnasium's spaces,
-        # SB3 raises an assertion error because the objects are not instances
-        # of ``gym.spaces.Space``.  To keep the environment gymnasium-based
-        # while staying compatible with SB3 we instantiate equivalent spaces
-        # from the legacy ``gym`` package.
-        self.action_space = spaces.Discrete(experiment.ACTION_SPACE_SIZE)
+        # Define action and observation spaces. The agent now outputs a joint
+        # action for all controlled vehicles at each step, therefore the action
+        # space becomes MultiDiscrete with one discrete action per vehicle.
+        if self.config and "controlled_cars" in self.config:
+            self.num_cars = len(self.config["controlled_cars"])
+        else:
+            self.num_cars = getattr(self.experiment, "CARS_AMOUNT", 1)
 
-        # Observation space: combined car state and embedding
-        # Car state is 4-dimensional (x, y, vx, vy) and embedding is 4-dimensional
-        # Stable-Baselines3 requires finite bounds for Box spaces.  While the
-        # underlying observation does not have hard physical limits, we can use
-        # the maximum finite value representable in float32 to approximate
-        # unbounded ranges while satisfying the API contract.
+        self.action_space = spaces.MultiDiscrete(
+            np.full(self.num_cars, experiment.ACTION_SPACE_SIZE, dtype=np.int64)
+        )
+
+        # Observation space: concatenated per-vehicle observation (4-dim state +
+        # shared embedding) for all controlled vehicles.
+        per_vehicle_obs_dim = experiment.STATE_INPUT_SIZE
+        observation_dim = self.num_cars * per_vehicle_obs_dim
         self.observation_space = spaces.Box(
             low=-np.inf,
             high=np.inf,
-            shape=(experiment.STATE_INPUT_SIZE,),  # Default is 8 (4 car state + 4 embedding)
+            shape=(observation_dim,),
             dtype=np.float32
         )
 
@@ -71,23 +71,18 @@ class Driver(gym.Env):
 
 
     @staticmethod
-    def get_action(model, car_observations, step_counter, exploration_threshold):
-        actions = []  # will collect one action per car (same order as observations)
-
+    def get_action(model, observation, step_counter, exploration_threshold):
+        """Return the joint action for all vehicles."""
         if step_counter < exploration_threshold:
-            # --- RANDOM PHASE: before the threshold, pick 0/1 at random for each car ---
-            for _ in car_observations:
-                # Choose a discrete action 0 or 1 uniformly at random
-                a = random.choice([0, 1])  # new: replaces the old exp-decay exploration rule
-                # Ensure the action has the same shape/type as model.predict output (e.g., [0] / [1])
-                actions.append(np.array([a], dtype=np.int64))  # new: keep 1-D, length-1 action
+            # Random exploration: sample once from the joint action space
+            joint_action = model.action_space.sample()
         else:
-            # --- POLICY PHASE: after the threshold, use the model deterministically ---
-            for obs in car_observations:
-                car_action, _ = model.predict(obs, deterministic=True)  # unchanged: use policy
-                actions.append(car_action)
+            # Policy exploitation: predict deterministically from the current observation
+            action, _ = model.predict(observation, deterministic=True)
+            joint_action = np.asarray(action)
 
-        return actions
+        joint_action = np.asarray(joint_action).astype(np.int64).flatten()
+        return joint_action
 
 
     def _prepare_state_for_master(self, state):
@@ -144,21 +139,28 @@ class Driver(gym.Env):
             raise ValueError("master not available")
 
         # Build agent_observations
+        self.num_cars = len(env.controlled_vehicles)
+        embedding_array = np.asarray(self.current_embedding, dtype=np.float32)
         agent_observations = []  # TODO: duplicate code, move to utils
 
-        for car_index in range(len(env.controlled_vehicles)):
-
+        for car_index in range(self.num_cars):
             if (hasattr(env, 'controlled_vehicles') and len(env.controlled_vehicles) > 0 and
                     hasattr(env.controlled_vehicles[car_index], 'is_arrived') and env.controlled_vehicles[car_index].is_arrived):
-                car_state = np.array([0.0, 0.0, 0.0, 0.0])
-                print('The',env.controlled_vehicles[car_index],'Arrived and sending : ', car_state)
+                car_state = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+                print('The', env.controlled_vehicles[car_index], 'Arrived and sending : ', car_state)
             else:
-                car_state = current_state[car_index*4:car_index*4+4] if len(current_state.shape) == 1 else current_state[car_index]
+                if len(current_state.shape) == 1:
+                    car_state = current_state[car_index * 4:car_index * 4 + 4]
+                else:
+                    car_state = current_state[car_index]
+                car_state = np.asarray(car_state, dtype=np.float32)
 
-            agent_observations.append(np.concatenate((car_state, self.current_embedding)))
+            agent_observations.append(np.concatenate((car_state, embedding_array)))
 
+        stacked_obs = np.stack(agent_observations, axis=0).astype(np.float32)
+        flat_obs = stacked_obs.reshape(-1)
 
-        return agent_observations, info
+        return flat_obs, info
 
     def step(self, action_tuple):
         """Execute action and return observations for both agents."""
@@ -178,24 +180,32 @@ class Driver(gym.Env):
 
         # Build agent_observations
         agent_next_observations = []  # TODO: duplicate code, move to utils
+        embedding_array = np.asarray(self.current_embedding, dtype=np.float32)
 
         for car_index in range(len(env.controlled_vehicles)):
 
             if (hasattr(env, 'controlled_vehicles') and len(env.controlled_vehicles) > 0 and
                     hasattr(env.controlled_vehicles[car_index], 'is_arrived') and env.controlled_vehicles[
                         car_index].is_arrived):
-                car_state = np.array([0.0, 0.0, 0.0, 0.0])
+                car_state = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
                 print('The', env.controlled_vehicles[car_index], 'Arrived and sending : ', car_state)
             else:
-                car_state = next_state[car_index * 4:car_index * 4 + 4] if len(next_state.shape) == 1 else next_state[car_index]
+                if len(next_state.shape) == 1:
+                    car_state = next_state[car_index * 4:car_index * 4 + 4]
+                else:
+                    car_state = next_state[car_index]
+                car_state = np.asarray(car_state, dtype=np.float32)
 
-            agent_next_observations.append(np.concatenate((car_state, self.current_embedding)))
+            agent_next_observations.append(np.concatenate((car_state, embedding_array)))
+
+        stacked_next_obs = np.stack(agent_next_observations, axis=0).astype(np.float32)
+        flat_next_obs = stacked_next_obs.reshape(-1)
 
         self.current_state = next_state
         self.total_episode_reward += reward
 
         # Return same format as reset() - both observations
-        return agent_next_observations, reward, done, truncated, info
+        return flat_next_obs, reward, done, truncated, info
 
     def render(self, mode='human'):
         """

--- a/src/model/master_model.py
+++ b/src/model/master_model.py
@@ -83,9 +83,12 @@ class AttentionPolicyNetwork(nn.Module):
         batch_size = observations.shape[0]
         reshaped = observations.view(batch_size, self.num_agents, self.per_agent_obs_dim)
         encoded = self.entity_encoder(reshaped)
+        attention_inputs = self.encoder_to_attention(encoded)
 
         # Each agent attends to every other agent and itself
-        attention_context, attention_weights = self.attention(encoded, encoded, encoded, need_weights=True)
+        attention_context, attention_weights = self.attention(
+            attention_inputs, attention_inputs, attention_inputs, need_weights=True
+        )
         self._last_attention_weights = attention_weights.detach()
 
         actions = self.decoder(attention_context)

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -4,11 +4,12 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 import numpy as np
+import torch
 
 from src import project_globals
 from src.model.agent_handler import Driver
 from src.project_globals import rollout_buffers
-from src.training.general_utils import ensure_tensor, get_agent_values_from_observation, get_scaler_action_and_action_array
+from src.training.general_utils import ensure_tensor
 from src.training.rollout_buffer_utils import reset_all_buffers
 
 
@@ -22,6 +23,7 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
     crashed = False
 
     car_observations, _ = env.reset()
+    car_observations = np.asarray(car_observations, dtype=np.float32)
     done, truncated = False, False
 
     while not done and not truncated:
@@ -33,50 +35,26 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         # Master embedding (and its value/log_prob if needed)
         embedding, _, _ = master_model.get_proto_action(ensure_tensor(all_drivers_states))
 
-        # Agent actions
-        actions = Driver.get_action(
+        # Agent actions (joint for all vehicles)
+        joint_actions = Driver.get_action(
             agent_model,
             car_observations,
             total_steps,
             experiment.EXPLORATION_EXPLOITATION_THRESHOLD
         )
+        actions_per_episode.append(joint_actions.tolist())
 
-        cars_scalar_action, cars_action_arrays = [], []
-        for action in actions:
-            car_scalar_action, car_action_array = get_scaler_action_and_action_array(action)
-            cars_scalar_action.append(car_scalar_action)
-            cars_action_arrays.append(car_action_array)
-
-        # Build per-car observations consistent with training: [car_state, embedding]
-        agent_obs_list = []
-        expected_dim = agent_model.policy.observation_space.shape[0]
-        for car_index in range(len(car_observations)):
-            # take first 4 features of this car (as elsewhere in code)
-            car_state = np.array(car_observations[car_index]).flatten()[:4]
-            agent_obs = np.concatenate((car_state, np.asarray(embedding).flatten()))
-            if agent_obs.shape[0] != expected_dim:
-                if agent_obs.shape[0] > expected_dim:
-                    agent_obs = agent_obs[:expected_dim]
-                else:
-                    pad = np.zeros(expected_dim - agent_obs.shape[0], dtype=np.float32)
-                    agent_obs = np.concatenate([agent_obs, pad])
-            agent_obs_list.append(agent_obs.astype(np.float32))
-
-        # Values / log-probs for agent (only when needed)
-        cars_values, cars_log_probas = [], []
+        joint_values = joint_log_probs = None
         if train_both or not training_master:
-            for car_index in range(len(car_observations)):
-                car_values, car_log_prob = get_agent_values_from_observation(
-                    agent_obs_list[car_index],
-                    cars_action_arrays[car_index],
-                    agent_model
-                )
-                cars_values.append(car_values)
-                cars_log_probas.append(car_log_prob)
+            obs_tensor = torch.tensor(car_observations, dtype=torch.float32).unsqueeze(0)
+            joint_values = agent_model.policy.predict_values(obs_tensor).detach().cpu().numpy().flatten()
+            dist = agent_model.policy.get_distribution(obs_tensor)
+            action_tensor = torch.tensor(joint_actions, dtype=torch.int64).unsqueeze(0)
+            joint_log_probs = dist.log_prob(action_tensor).detach().cpu().numpy().flatten()
 
         env.render()
 
-        action_tuple = tuple(cars_scalar_action)
+        action_tuple = tuple(int(a) for a in joint_actions)
         cars_next_obs, reward, done, truncated, info = env.step(action_tuple)
         episode_sum_of_rewards += reward
         all_rewards.append(reward)
@@ -98,20 +76,18 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
                 done_flag,
             )
 
-        # Add to agent rollout buffers
+        # Add to agent rollout buffer
         if train_both or not training_master:
-            for car_index in range(len(project_globals.after_is_arrived_flags)):
-                if not project_globals.after_is_arrived_flags[car_index]:
-                    rollout_buffers[car_index].add(
-                        agent_obs_list[car_index],
-                        cars_action_arrays[car_index],
-                        reward,
-                        done_flag,
-                        cars_values[car_index],
-                        cars_log_probas[car_index]
-                    )
+            rollout_buffers[0].add(
+                car_observations,
+                np.asarray(joint_actions, dtype=np.int64),
+                reward,
+                done_flag,
+                joint_values,
+                joint_log_probs
+            )
 
-        car_observations = cars_next_obs
+        car_observations = np.asarray(cars_next_obs, dtype=np.float32)
 
     return episode_sum_of_rewards, actions_per_episode, steps_counter, crashed
 

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -47,10 +47,10 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
         joint_values = joint_log_probs = None
         if train_both or not training_master:
             obs_tensor = torch.tensor(car_observations, dtype=torch.float32).unsqueeze(0)
-            joint_values = agent_model.policy.predict_values(obs_tensor).detach().cpu().numpy().flatten()
+            joint_values = agent_model.policy.predict_values(obs_tensor).detach().squeeze(0)
             dist = agent_model.policy.get_distribution(obs_tensor)
             action_tensor = torch.tensor(joint_actions, dtype=torch.int64).unsqueeze(0)
-            joint_log_probs = dist.log_prob(action_tensor).detach().cpu().numpy().flatten()
+            joint_log_probs = dist.log_prob(action_tensor).detach().squeeze(0)
 
         env.render()
 

--- a/src/training/training_handler.py
+++ b/src/training/training_handler.py
@@ -33,7 +33,7 @@ def training_loop(experiment, env, agent_model, master_model):
     rollout_buffers.clear()
     base_env = env.envs[0] if hasattr(env, "envs") else env
     num_cars = getattr(base_env, "num_cars", experiment.CARS_AMOUNT)
-    obs_dim = experiment.STATE_INPUT_SIZE * num_cars
+    obs_dim = experiment.AGENT_STATE_SIZE * num_cars
 
     obs_low = np.full((obs_dim,), -np.finfo(np.float32).max, dtype=np.float32)
     obs_high = np.full((obs_dim,), np.finfo(np.float32).max, dtype=np.float32)

--- a/src/training/training_handler.py
+++ b/src/training/training_handler.py
@@ -29,28 +29,28 @@ def training_loop(experiment, env, agent_model, master_model):
     Main training loop that orchestrates cycles and episodes.
     """
 
-    # Add rollout buffer per controlled car
-    for _ in env.env.config["controlled_cars"]:
-        obs_low = np.full(
-            (experiment.STATE_INPUT_SIZE,),
-            -np.finfo(np.float32).max,
-            dtype=np.float32,
-        )
-        obs_high = np.full(
-            (experiment.STATE_INPUT_SIZE,),
-            np.finfo(np.float32).max,
-            dtype=np.float32,
-        )
+    # Prepare a single rollout buffer for the joint observation/action pair
+    rollout_buffers.clear()
+    base_env = env.envs[0] if hasattr(env, "envs") else env
+    num_cars = getattr(base_env, "num_cars", experiment.CARS_AMOUNT)
+    obs_dim = experiment.STATE_INPUT_SIZE * num_cars
 
-        new_rollout_buffer_instance = RolloutBuffer(
-            buffer_size=experiment.N_STEPS,
-            observation_space=spaces.Box(low=obs_low, high=obs_high, dtype=np.float32),
-            action_space=spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32),
-            gamma=0.99,
-            gae_lambda=0.95,
-            n_envs=1
-        )
-        rollout_buffers.append(new_rollout_buffer_instance)
+    obs_low = np.full((obs_dim,), -np.finfo(np.float32).max, dtype=np.float32)
+    obs_high = np.full((obs_dim,), np.finfo(np.float32).max, dtype=np.float32)
+
+    joint_action_space = spaces.MultiDiscrete(
+        np.full(num_cars, experiment.ACTION_SPACE_SIZE, dtype=np.int64)
+    )
+
+    new_rollout_buffer_instance = RolloutBuffer(
+        buffer_size=experiment.N_STEPS,
+        observation_space=spaces.Box(low=obs_low, high=obs_high, dtype=np.float32),
+        action_space=joint_action_space,
+        gamma=0.99,
+        gae_lambda=0.95,
+        n_envs=1
+    )
+    rollout_buffers.append(new_rollout_buffer_instance)
 
 
     collision_counter, episode_counter, total_steps = 0, 0, 0
@@ -148,9 +148,10 @@ def run_evaluation(experiment_config, env, agent_model):
 
         while not done and not truncated:
             action, _ = agent_model.predict(obs, deterministic=True)
-            obs, reward, done, truncated, info = env.step(action)
+            joint_action = np.asarray(action).astype(np.int64).flatten()
+            obs, reward, done, truncated, info = env.step(tuple(int(a) for a in joint_action))
             episode_reward += reward
-            actions.append(action[0])
+            actions.append(joint_action.tolist())
             env.render()
 
         eval_rewards.append(episode_reward)

--- a/src/training/training_loop_utils.py
+++ b/src/training/training_loop_utils.py
@@ -5,7 +5,7 @@ from typing import Tuple, List, Dict, Any
 import numpy as np
 import torch
 
-from src.training.general_utils import ensure_tensor, flatten_obs, combine_agent_obs
+from src.training.general_utils import ensure_tensor
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -102,11 +102,21 @@ def train_agent_and_reset_buffer(master_model, agent_model, last_master_tensor):
             with torch.no_grad():
                 shaped_tensor = ensure_tensor(last_master_tensor)
                 embedding, _, _ = master_model.get_proto_action(shaped_tensor)
-                car_state = flatten_obs(last_master_tensor)
-                expected_dim = agent_model.policy.observation_space.shape[0]
-                agent_obs = combine_agent_obs(car_state, embedding, expected_dim)
+                num_cars = len(agent_model.action_space.nvec)
+                master_state_np = np.array(last_master_tensor, dtype=np.float32).reshape(-1)
+                expected_state_size = num_cars * 4
+                if master_state_np.size < expected_state_size:
+                    padded_state = np.zeros(expected_state_size, dtype=np.float32)
+                    padded_state[: master_state_np.size] = master_state_np
+                    master_state_np = padded_state
+                elif master_state_np.size > expected_state_size:
+                    master_state_np = master_state_np[:expected_state_size]
+                car_states = master_state_np.reshape(num_cars, 4)
+                embedding_array = np.asarray(embedding, dtype=np.float32)
+                per_agent_obs = [np.concatenate((car_states[idx], embedding_array)) for idx in range(num_cars)]
+                agent_obs = np.stack(per_agent_obs, axis=0).astype(np.float32).reshape(-1)
                 agent_obs_tensor = torch.tensor(agent_obs, dtype=torch.float32).unsqueeze(0)
-                last_value = agent_model.policy.predict_values(agent_obs_tensor)
+                last_value = agent_model.policy.predict_values(agent_obs_tensor).detach().cpu().numpy().reshape(-1)
 
             if current_rollout_buffer.pos == 0:
                 print("Agent model: No data to train on")
@@ -136,8 +146,8 @@ def train_agent_and_reset_buffer(master_model, agent_model, last_master_tensor):
                 if rollout_data is not None:
                     steps_trained = len(rollout_data.observations)
                     print(f"Agent model trained on {steps_trained} steps")
-                    observations_tensor = torch.FloatTensor(rollout_data.observations)
-                    actions_tensor = torch.FloatTensor(rollout_data.actions)
+                    observations_tensor = torch.tensor(rollout_data.observations, dtype=torch.float32)
+                    actions_tensor = torch.tensor(rollout_data.actions, dtype=torch.int64)
                     policy = agent_model.policy
                     optimizer = policy.optimizer
                     values, log_probs, entropy = policy.evaluate_actions(observations_tensor, actions_tensor)


### PR DESCRIPTION
## Summary
- update the Driver environment to expose a multi-vehicle MultiDiscrete action space and flattened joint observations
- adapt episode processing and rollout storage to use single joint actions covering every controlled vehicle
- refresh the training utilities and evaluation flow to compute values, log probabilities, and actions for the new joint format

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_690b662ba6c883329c75d1fab0b2f61f