### PR TITLE
Refactor agent training to remove master dependency

### DIFF
--- a/logger/utils.py
+++ b/logger/utils.py
@@ -4,21 +4,21 @@ def log_training_results_to_neptune(logger, training_results):
     """
     Logs training results (reward/losses per episode) to Neptune.
     """
-    episode_rewards = training_results["episode_rewards"]
-    master_policy_losses = training_results["master_policy_losses"]
-    master_value_losses = training_results["master_value_losses"]
-    master_total_losses = training_results["master_total_losses"]
-    agent_policy_losses = training_results["agent_policy_losses"]
-    agent_value_losses = training_results["agent_value_losses"]
-    agent_total_losses = training_results["agent_total_losses"]
+    episode_rewards = training_results.get("episode_rewards", [])
+    master_policy_losses = training_results.get("master_policy_losses", [])
+    master_value_losses = training_results.get("master_value_losses", [])
+    master_total_losses = training_results.get("master_total_losses", [])
+    agent_policy_losses = training_results.get("agent_policy_losses", [])
+    agent_value_losses = training_results.get("agent_value_losses", [])
+    agent_total_losses = training_results.get("agent_total_losses", [])
 
     for i in range(len(episode_rewards)):
         logger.log_metric("episode/reward", episode_rewards[i])
-        if master_policy_losses[i] is not None:
+        if i < len(master_policy_losses) and master_policy_losses[i] is not None:
             logger.log_metric("master/policy_loss", master_policy_losses[i])
             logger.log_metric("master/value_loss", master_value_losses[i])
             logger.log_metric("master/total_loss", master_total_losses[i])
-        if agent_policy_losses[i] is not None:
+        if i < len(agent_policy_losses) and agent_policy_losses[i] is not None:
             logger.log_metric("agent/policy_loss", agent_policy_losses[i])
             logger.log_metric("agent/value_loss", agent_value_losses[i])
             logger.log_metric("agent/total_loss", agent_total_losses[i])

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -42,6 +42,17 @@ class AttentionObservationEncoder(BaseFeaturesExtractor):
 
     def forward(self, observations: torch.Tensor) -> torch.Tensor:
         batch_size = observations.shape[0]
+        expected_dim = self.num_agents * self.per_agent_obs_dim
+        current_dim = observations.shape[1]
+
+        if current_dim != expected_dim:
+            if current_dim > expected_dim:
+                observations = observations[:, :expected_dim]
+            else:
+                pad_size = expected_dim - current_dim
+                padding = torch.zeros((batch_size, pad_size), dtype=observations.dtype, device=observations.device)
+                observations = torch.cat([observations, padding], dim=1)
+
         reshaped = observations.view(batch_size, self.num_agents, self.per_agent_obs_dim)
         encoded = self.encoder(reshaped)
         attn_input = self.to_attention(encoded)

--- a/src/model/agent_handler.py
+++ b/src/model/agent_handler.py
@@ -1,30 +1,64 @@
 import random
+import warnings
 
 import gymnasium as gym
 import numpy as np
 import torch
-from gym import spaces as gym_spaces
-import warnings
-
+import torch.nn as nn
 from gymnasium import spaces
+from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
 
 warnings.filterwarnings("ignore")
 
+
+class AttentionObservationEncoder(BaseFeaturesExtractor):
+    """Attention-based feature extractor mirroring the master architecture."""
+
+    def __init__(
+        self,
+        observation_space: spaces.Box,
+        *,
+        num_agents: int,
+        per_agent_obs_dim: int,
+        attention_embed_dim: int = 128,
+        encoder_hidden_dim: int = 64,
+        num_heads: int = 2,
+    ) -> None:
+        super().__init__(observation_space, features_dim=num_agents * attention_embed_dim)
+        self.num_agents = num_agents
+        self.per_agent_obs_dim = per_agent_obs_dim
+        self.encoder = nn.Sequential(
+            nn.Linear(per_agent_obs_dim, encoder_hidden_dim),
+            nn.ReLU(),
+            nn.Linear(encoder_hidden_dim, encoder_hidden_dim),
+            nn.ReLU(),
+        )
+        self.to_attention = nn.Linear(encoder_hidden_dim, attention_embed_dim)
+        self.attention = nn.MultiheadAttention(
+            embed_dim=attention_embed_dim,
+            num_heads=num_heads,
+            batch_first=True,
+        )
+
+    def forward(self, observations: torch.Tensor) -> torch.Tensor:
+        batch_size = observations.shape[0]
+        reshaped = observations.view(batch_size, self.num_agents, self.per_agent_obs_dim)
+        encoded = self.encoder(reshaped)
+        attn_input = self.to_attention(encoded)
+        attn_output, _ = self.attention(attn_input, attn_input, attn_input)
+        return attn_output.reshape(batch_size, -1)
+
 class Driver(gym.Env):
-    """
-    Agent environment wrapper for Highway intersection.
+    """Agent environment wrapper for the Highway intersection task.
 
-    This wrapper interfaces with the Highway environment and integrates
-    the master model's embedding into the agent's observation.
-
-    The agent controls only one car (car1) and receives information about
-    all cars in the environment through the master embedding.
+    The wrapper exposes per-vehicle kinematic states for all controlled cars,
+    allowing attention-based policies to learn interactions directly from the
+    raw observations without requiring a separate master model.
     """
 
-    def __init__(self, experiment, master_model=None):
+    def __init__(self, experiment):
         super().__init__()
         self.experiment = experiment
-        self.master_model = master_model
 
         # Load environment configuration
         self.config = experiment.CONFIG if hasattr(experiment, 'CONFIG') else None
@@ -41,8 +75,8 @@ class Driver(gym.Env):
             np.full(self.num_cars, experiment.ACTION_SPACE_SIZE, dtype=np.int64)
         )
 
-        # Observation space: concatenated per-vehicle observation (4-dim state +
-        # shared embedding) for all controlled vehicles.
+        # Observation space: concatenated per-vehicle kinematic state for all
+        # controlled vehicles (flattened for compatibility with vector policies).
         per_vehicle_obs_dim = experiment.AGENT_STATE_SIZE
         observation_dim = self.num_cars * per_vehicle_obs_dim
         self.observation_space = spaces.Box(
@@ -58,8 +92,6 @@ class Driver(gym.Env):
 
         # Environment state
         self.current_state = None
-        self.current_embedding = None
-
         # Create the underlying Highway environment
         self.highway_env = gym.make('RELintersection-v0', render_mode=experiment.RENDER_MODE, config=self.config)
 
@@ -85,7 +117,7 @@ class Driver(gym.Env):
         return joint_action
 
 
-    def _prepare_state_for_master(self, state):
+    def _prepare_state(self, state):
         if isinstance(state, tuple):
             state = np.array(state)
         elif not isinstance(state, np.ndarray):
@@ -129,18 +161,10 @@ class Driver(gym.Env):
                 if hasattr(vehicle, 'is_arrived'):
                     delattr(vehicle, 'is_arrived')
 
-        current_state = self._prepare_state_for_master(current_state)
-
-        if self.master_model is not None:
-            master_input = torch.tensor(current_state.reshape(1, -1), dtype=torch.float32)
-            embedding, _, _ = self.master_model.get_proto_action(master_input)
-            self.current_embedding = embedding
-        else:
-            raise ValueError("master not available")
+        current_state = self._prepare_state(current_state)
 
         # Build agent_observations
         self.num_cars = len(env.controlled_vehicles)
-        embedding_array = np.asarray(self.current_embedding, dtype=np.float32)
         agent_observations = []  # TODO: duplicate code, move to utils
 
         for car_index in range(self.num_cars):
@@ -155,7 +179,6 @@ class Driver(gym.Env):
                     car_state = current_state[car_index]
                 car_state = np.asarray(car_state, dtype=np.float32)
 
-            # agent_observations.append(np.concatenate((car_state, embedding_array)))
             agent_observations.append(car_state)
 
         stacked_obs = np.stack(agent_observations, axis=0).astype(np.float32)
@@ -168,20 +191,12 @@ class Driver(gym.Env):
         self.episode_step += 1
 
         next_state, reward, done, truncated, info = self.highway_env.step(action_tuple)
-        next_state = self._prepare_state_for_master(next_state)
-
-        if self.master_model is not None:
-            master_input = torch.tensor(next_state.reshape(1, -1), dtype=torch.float32)
-            embedding, _, _ = self.master_model.get_proto_action(master_input)
-            self.current_embedding = embedding
-        else:
-            self.current_embedding = np.zeros(4)
+        next_state = self._prepare_state(next_state)
 
         env = self._get_unwrapped_env()
 
         # Build agent_observations
         agent_next_observations = []  # TODO: duplicate code, move to utils
-        embedding_array = np.asarray(self.current_embedding, dtype=np.float32)
 
         for car_index in range(len(env.controlled_vehicles)):
 
@@ -197,7 +212,6 @@ class Driver(gym.Env):
                     car_state = next_state[car_index]
                 car_state = np.asarray(car_state, dtype=np.float32)
 
-            # agent_next_observations.append(np.concatenate((car_state, embedding_array)))
             agent_next_observations.append(car_state)
 
         stacked_next_obs = np.stack(agent_next_observations, axis=0).astype(np.float32)

--- a/src/model/model_handler.py
+++ b/src/model/model_handler.py
@@ -75,10 +75,11 @@ class Model:
 
 
 def load_models(agent_model, master_model, load_dir):
-    """Try loading agent and master model weights."""
+    """Try loading agent (and optionally master) model weights."""
     try:
         agent_model.load(f"{load_dir}_agent.pth")
-        master_model.load(f"{load_dir}_master.pth")
+        if master_model is not None:
+            master_model.load(f"{load_dir}_master.pth")
         print(f"Loaded weights from {load_dir}.")
         return True
     except Exception as e:
@@ -86,7 +87,8 @@ def load_models(agent_model, master_model, load_dir):
         return False
 
 def save_models(agent_model, master_model, save_dir):
-    """Save agent and master model weights."""
+    """Save agent (and optionally master) model weights."""
     agent_model.save(f"{save_dir}_agent.pth")
-    master_model.save(f"{save_dir}_master.pth")
+    if master_model is not None:
+        master_model.save(f"{save_dir}_master.pth")
     print("Models saved.")

--- a/src/plotting_utils/plotting_utils.py
+++ b/src/plotting_utils/plotting_utils.py
@@ -18,12 +18,9 @@ def plot_training_results(experiment, results, show_plots=True):
 
     # Unpack the results
     episode_rewards = results["episode_rewards"]
-    master_policy_losses = results["master_policy_losses"]
-    master_value_losses = results["master_value_losses"]
-    master_total_losses = results["master_total_losses"]
-    agent_policy_losses = results["agent_policy_losses"]
-    agent_value_losses = results["agent_value_losses"]
-    agent_total_losses = results["agent_total_losses"]
+    agent_policy_losses = results.get("agent_policy_losses", [])
+    agent_value_losses = results.get("agent_value_losses", [])
+    agent_total_losses = results.get("agent_total_losses", [])
 
     # Create x-axis for episodes
     episodes = np.arange(1, len(episode_rewards) + 1)
@@ -46,47 +43,7 @@ def plot_training_results(experiment, results, show_plots=True):
     else:
         plt.close()
 
-    # 2. Plot Master value loss
-    plt.figure(figsize=(10, 6))
-    valid_indices = [i for i, val in enumerate(master_value_losses) if val is not None]
-    valid_episodes = [episodes[i] for i in valid_indices]
-    valid_losses = [master_value_losses[i] for i in valid_indices]
-
-    if valid_losses:
-        plt.plot(valid_episodes, valid_losses, 'o-', color='#D95F02', linewidth=2, markersize=6)
-        plt.grid(True, alpha=0.3)
-        plt.title('Master Value Loss', fontsize=16)
-        plt.xlabel('Episode', fontsize=14)
-        plt.ylabel('Loss', fontsize=14)
-        plt.yscale('log')  # Use log scale since losses can vary greatly
-        plt.tight_layout()
-        plt.savefig(os.path.join(plots_dir, 'master_value_loss.png'))
-        if show_plots:
-            plt.show()
-        else:
-            plt.close()
-
-    # 3. Plot Master total loss
-    plt.figure(figsize=(10, 6))
-    valid_indices = [i for i, val in enumerate(master_total_losses) if val is not None]
-    valid_episodes = [episodes[i] for i in valid_indices]
-    valid_losses = [master_total_losses[i] for i in valid_indices]
-
-    if valid_losses:
-        plt.plot(valid_episodes, valid_losses, 'o-', color='#7570B3', linewidth=2, markersize=6)
-        plt.grid(True, alpha=0.3)
-        plt.title('Master Total Loss', fontsize=16)
-        plt.xlabel('Episode', fontsize=14)
-        plt.ylabel('Loss', fontsize=14)
-        plt.yscale('log')  # Use log scale since losses can vary greatly
-        plt.tight_layout()
-        plt.savefig(os.path.join(plots_dir, 'master_total_loss.png'))
-        if show_plots:
-            plt.show()
-        else:
-            plt.close()
-
-    # 4. Plot Agent value loss
+    # 2. Plot Agent value loss
     plt.figure(figsize=(10, 6))
     valid_indices = [i for i, val in enumerate(agent_value_losses) if val is not None]
     valid_episodes = [episodes[i] for i in valid_indices]
@@ -106,7 +63,7 @@ def plot_training_results(experiment, results, show_plots=True):
         else:
             plt.close()
 
-    # 5. Plot Agent total loss
+    # 3. Plot Agent total loss
     plt.figure(figsize=(10, 6))
     valid_indices = [i for i, val in enumerate(agent_total_losses) if val is not None]
     valid_episodes = [episodes[i] for i in valid_indices]
@@ -126,13 +83,27 @@ def plot_training_results(experiment, results, show_plots=True):
         else:
             plt.close()
 
-    plt.figure(figsize=(12, 8))
+    # 4. Plot Agent policy loss
+    plt.figure(figsize=(10, 6))
+    valid_indices = [i for i, val in enumerate(agent_policy_losses) if val is not None]
+    valid_episodes = [episodes[i] for i in valid_indices]
+    valid_losses = [agent_policy_losses[i] for i in valid_indices]
 
-    # Master losses
-    master_valid_indices = [i for i, val in enumerate(master_total_losses) if val is not None]
-    master_valid_episodes = [episodes[i] for i in master_valid_indices]
-    master_valid_total_losses = [master_total_losses[i] for i in master_valid_indices]
-    master_valid_value_losses = [master_value_losses[i] for i in master_valid_indices]
+    if valid_losses:
+        plt.plot(valid_episodes, valid_losses, 'o-', color='#66A61E', linewidth=2, markersize=6)
+        plt.grid(True, alpha=0.3)
+        plt.title('Agent Policy Loss', fontsize=16)
+        plt.xlabel('Episode', fontsize=14)
+        plt.ylabel('Loss', fontsize=14)
+        plt.yscale('log')
+        plt.tight_layout()
+        plt.savefig(os.path.join(plots_dir, 'agent_policy_loss.png'))
+        if show_plots:
+            plt.show()
+        else:
+            plt.close()
+
+    plt.figure(figsize=(12, 8))
 
     # Agent losses
     agent_valid_indices = [i for i, val in enumerate(agent_total_losses) if val is not None]
@@ -140,17 +111,18 @@ def plot_training_results(experiment, results, show_plots=True):
     agent_valid_total_losses = [agent_total_losses[i] for i in agent_valid_indices]
     agent_valid_value_losses = [agent_value_losses[i] for i in agent_valid_indices]
 
-    if master_valid_total_losses:
-        plt.plot(master_valid_episodes, master_valid_total_losses, 'o-', label='Master Total Loss',
-                 color='#7570B3', linewidth=2, markersize=6)
-        plt.plot(master_valid_episodes, master_valid_value_losses, 's-', label='Master Value Loss',
-                 color='#D95F02', linewidth=2, markersize=6)
-
     if agent_valid_total_losses:
         plt.plot(agent_valid_episodes, agent_valid_total_losses, 'o-', label='Agent Total Loss',
                  color='#E7298A', linewidth=2, markersize=6)
         plt.plot(agent_valid_episodes, agent_valid_value_losses, 's-', label='Agent Value Loss',
                  color='#1B9E77', linewidth=2, markersize=6)
+
+    agent_valid_policy_indices = [i for i, val in enumerate(agent_policy_losses) if val is not None]
+    if agent_valid_policy_indices:
+        agent_valid_policy_episodes = [episodes[i] for i in agent_valid_policy_indices]
+        agent_valid_policy_losses = [agent_policy_losses[i] for i in agent_valid_policy_indices]
+        plt.plot(agent_valid_policy_episodes, agent_valid_policy_losses, '^-', label='Agent Policy Loss',
+                 color='#66A61E', linewidth=2, markersize=6)
 
     plt.grid(True, alpha=0.3)
     plt.title('Training Losses', fontsize=16)
@@ -176,13 +148,12 @@ def plot_training_results(experiment, results, show_plots=True):
     ax1.grid(True, alpha=0.3)
 
     # Plot losses on second axis
-    if master_valid_total_losses:
-        ax2.plot(master_valid_episodes, master_valid_total_losses, 'o-', label='Master Loss',
-                 color='#7570B3', linewidth=2, markersize=6)
-
     if agent_valid_total_losses:
         ax2.plot(agent_valid_episodes, agent_valid_total_losses, 'o-', label='Agent Loss',
                  color='#E7298A', linewidth=2, markersize=6)
+    if agent_valid_policy_indices:
+        ax2.plot(agent_valid_policy_episodes, agent_valid_policy_losses, '^-', label='Agent Policy Loss',
+                 color='#66A61E', linewidth=2, markersize=6)
 
     ax2.set_title('Training Losses', fontsize=16)
     ax2.set_xlabel('Episode', fontsize=14)

--- a/src/training/episode_utils.py
+++ b/src/training/episode_utils.py
@@ -6,10 +6,8 @@ logger = logging.getLogger(__name__)
 import numpy as np
 import torch
 
-from src import project_globals
 from src.model.agent_handler import Driver
 from src.project_globals import rollout_buffers
-from src.training.general_utils import ensure_tensor
 from src.training.rollout_buffer_utils import reset_all_buffers
 
 
@@ -17,7 +15,7 @@ def reshape_drivers_states(all_drivers_states):
     all_drivers_states = all_drivers_states.reshape(-1) if isinstance(all_drivers_states, np.ndarray) and len(all_drivers_states.shape) == 2 else all_drivers_states
     return all_drivers_states
 
-def run_episode(experiment, total_steps, env, master_model, agent_model, train_both, training_master):
+def run_episode(experiment, total_steps, env, agent_model, train_both, training_master):
     all_rewards, actions_per_episode = [], []
     steps_counter, episode_sum_of_rewards = 0, 0
     crashed = False
@@ -28,12 +26,6 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
 
     while not done and not truncated:
         steps_counter += 1
-
-        # Get all drivers states (without master embedding) from environment
-        all_drivers_states = env.env.current_state
-
-        # Master embedding (and its value/log_prob if needed)
-        embedding, _, _ = master_model.get_proto_action(ensure_tensor(all_drivers_states))
 
         # Agent actions (joint for all vehicles)
         joint_actions = Driver.get_action(
@@ -64,17 +56,6 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
 
         # flags for buffers
         done_flag = bool(done or truncated)
-
-        # Store experience for the master model
-        if master_model.last_joint_action is not None:
-            next_state_snapshot = env.env.current_state
-            master_model.store_transition(
-                all_drivers_states,
-                master_model.last_joint_action,
-                reward,
-                next_state_snapshot,
-                done_flag,
-            )
 
         # Add to agent rollout buffer
         if train_both or not training_master:
@@ -163,7 +144,7 @@ def run_episode(experiment, total_steps, env, master_model, agent_model, train_b
 #     return episode_sum_of_rewards, actions_per_episode, steps_counter, crashed
 
 
-def process_episode(episode_idx, total_steps, env, master_model, agent_model, experiment, train_both, training_master):
+def process_episode(episode_idx, total_steps, env, agent_model, experiment, train_both, training_master):
     """
     Run an episode and log results.
     Returns: (reward, actions, steps, crashed)
@@ -173,8 +154,14 @@ def process_episode(episode_idx, total_steps, env, master_model, agent_model, ex
 
     # TODO: Create an assert here to see that they are reset propely
 
-    reward, actions, steps, crashed = run_episode(experiment, total_steps, env, master_model, agent_model,
-                                                  train_both=train_both, training_master=training_master)
+    reward, actions, steps, crashed = run_episode(
+        experiment,
+        total_steps,
+        env,
+        agent_model,
+        train_both=train_both,
+        training_master=training_master,
+    )
     status = "Collision" if crashed else "Success"
     if crashed:
         logger.warning("Episode %d ended with %s", episode_idx, status)

--- a/src/training/general_utils.py
+++ b/src/training/general_utils.py
@@ -4,8 +4,7 @@ import numpy as np
 import torch
 from stable_baselines3.common.logger import configure
 
-from src.model.agent_handler import Driver, DummyVecEnv
-from src.model.master_model import MasterModel
+from src.model.agent_handler import AttentionObservationEncoder, Driver, DummyVecEnv
 from src.model.model_handler import Model
 
 
@@ -102,33 +101,17 @@ def setup_experiment_dirs(experiment_path):
     os.makedirs(experiment_path, exist_ok=True)
 
 def initialize_models(experiment_config, env_config):
-    """
-    Initialize master and agent models, each with tuned architectures and hyperparameters.
-    d
-    """
+    """Initialize the agent model and wrapped environment."""
     experiment_config.CONFIG = env_config
 
-    # === MASTER MODEL CONFIGURATION ===
-    obs_dim = experiment_config.CARS_AMOUNT * 4
-    emb_dim = experiment_config.EMBEDDING_SIZE
+    num_agents = experiment_config.CARS_AMOUNT
+    per_agent_obs_dim = experiment_config.AGENT_STATE_SIZE
 
-    master_model = MasterModel(
-        observation_dim=obs_dim,
-        embedding_dim=emb_dim,
-    )
-
-    # === AGENT MODEL CONFIGURATION (FIXED) ===
-    AGENT_NETWORK_ARCH = {
-        'pi': [32,32],
-        'vf': [32,32]
-    }
-    AGENT_LR = 7e-4
-    AGENT_BATCH_SIZE = 128
-    env_fn = lambda: Driver(experiment_config, master_model=master_model)
+    env_fn = lambda: Driver(experiment_config)
     wrapped_env = DummyVecEnv([env_fn])
 
     agent_additional_model_params = {
-        'n_steps': 2048,         # must be divisible by batch_size
+        'n_steps': 2048,
         'gamma': 0.99,
         'gae_lambda': 0.95,
         'ent_coef': 0.0,
@@ -138,91 +121,41 @@ def initialize_models(experiment_config, env_config):
         'n_epochs': 10
     }
 
+    attention_policy_kwargs = dict(
+        features_extractor_class=AttentionObservationEncoder,
+        features_extractor_kwargs=dict(
+            num_agents=num_agents,
+            per_agent_obs_dim=per_agent_obs_dim,
+        ),
+        net_arch=[dict(pi=[64, 64], vf=[64, 64])],
+        activation_fn=torch.nn.ReLU,
+    )
+
     original_define_model_params = Model.define_model_params
 
     @staticmethod
     def improved_define_model_params(experiment):
         params = original_define_model_params(experiment)
         params.update(agent_additional_model_params)
-        params['learning_rate'] = AGENT_LR
-        params['batch_size']    = AGENT_BATCH_SIZE
-        params['policy_kwargs'] = dict(
-            activation_fn=torch.nn.ReLU,
-            net_arch=[dict(pi=AGENT_NETWORK_ARCH['pi'],
-                           vf=AGENT_NETWORK_ARCH['vf'])]
-        )
+        params['learning_rate'] = 7e-4
+        params['batch_size'] = 128
+        params['policy_kwargs'] = attention_policy_kwargs
         return params
 
     Model.define_model_params = improved_define_model_params
     agent_model = Model(wrapped_env, experiment_config).model
     Model.define_model_params = original_define_model_params
 
-    return master_model, agent_model, wrapped_env
+    return agent_model, wrapped_env
 
 
 def setup_loggers(base_path):
-    """Setup and return agent and master loggers."""
+    """Setup and return the agent logger."""
     agent_logger = configure(os.path.join(base_path, "agent_logs"), ["stdout", "csv", "tensorboard"])
-    master_logger = configure(os.path.join(base_path, "master_logs"), ["stdout", "csv", "tensorboard"])
-    return agent_logger, master_logger
+    return agent_logger
 
 
-def close_everything(env, agent_logger, master_logger):
+def close_everything(env, agent_logger):
     """Close environment and loggers."""
     env.close()
     agent_logger.close()
-    master_logger.close()
-
-
-def monitor_episode_results(master_model, agent_model):
-    """Print minimal statistics about the replay/rollout buffers."""
-    master_buffer_size = len(master_model.replay_buffer)
-    agent_buffer_size = agent_model.rollout_buffer.pos
-
-    print(
-        f"Current buffer sizes - Master replay: {master_buffer_size}, Agent rollout: {agent_buffer_size}"
-    )
-
-    if master_buffer_size > 0:
-        rewards = master_model.replay_buffer.rewards[:master_buffer_size]
-        print(
-            f"Episode rewards - Min: {rewards.min():.2f}, Max: {rewards.max():.2f}, Avg: {rewards.mean():.2f}"
-        )
-
-
-def monitor_rollout_buffers(master_model, agent_model):
-    """Print statistics about the replay and rollout buffers for debugging."""
-    print("\n--- Buffer Statistics ---")
-
-    print("Master replay buffer:")
-    print(f"  Capacity: {master_model.replay_buffer.capacity}")
-    print(f"  Current size: {len(master_model.replay_buffer)}")
-    print(f"  Observation dim: {master_model.replay_buffer.observation_dim}")
-    print(
-        f"  Action shape: ({master_model.replay_buffer.num_agents}, {master_model.replay_buffer.action_dim})"
-    )
-    if len(master_model.replay_buffer) > 0:
-        rewards = master_model.replay_buffer.rewards[: len(master_model.replay_buffer)]
-        print(
-            f"  Rewards stats: min={rewards.min():.4f}, max={rewards.max():.4f}, mean={rewards.mean():.4f}"
-        )
-
-    # Agent buffer stats
-    print("\nAgent rollout buffer:")
-    print(f"  Buffer size: {agent_model.rollout_buffer.buffer_size}")
-    print(f"  Current position: {agent_model.rollout_buffer.pos}")
-    print(f"  Is full: {agent_model.rollout_buffer.full}")
-
-    if hasattr(agent_model.rollout_buffer, 'observations') and agent_model.rollout_buffer.observations is not None:
-        print(f"  Observations shape: {agent_model.rollout_buffer.observations.shape}")
-
-    if hasattr(agent_model.rollout_buffer, 'actions') and agent_model.rollout_buffer.actions is not None:
-        print(f"  Actions shape: {agent_model.rollout_buffer.actions.shape}")
-
-    if hasattr(agent_model.rollout_buffer, 'rewards') and agent_model.rollout_buffer.rewards is not None:
-        rewards = agent_model.rollout_buffer.rewards[:agent_model.rollout_buffer.pos]
-        if len(rewards) > 0:
-            print(f"  Rewards stats: min={rewards.min():.4f}, max={rewards.max():.4f}, mean={rewards.mean():.4f}")
-            print(f"  Rewards: {rewards}")
-
-    print("-------------------------------\n")

--- a/src/training/general_utils.py
+++ b/src/training/general_utils.py
@@ -104,11 +104,17 @@ def initialize_models(experiment_config, env_config):
     """Initialize the agent model and wrapped environment."""
     experiment_config.CONFIG = env_config
 
-    num_agents = experiment_config.CARS_AMOUNT
-    per_agent_obs_dim = experiment_config.AGENT_STATE_SIZE
-
     env_fn = lambda: Driver(experiment_config)
     wrapped_env = DummyVecEnv([env_fn])
+
+    per_agent_obs_dim = experiment_config.AGENT_STATE_SIZE
+    observation_dim = int(np.prod(wrapped_env.observation_space.shape))
+    if observation_dim % per_agent_obs_dim != 0:
+        raise ValueError(
+            "Observation dimension is not divisible by per-agent observation size. "
+            f"Got observation_dim={observation_dim} and per_agent_obs_dim={per_agent_obs_dim}."
+        )
+    num_agents = observation_dim // per_agent_obs_dim
 
     agent_additional_model_params = {
         'n_steps': 2048,

--- a/src/training/training_handler.py
+++ b/src/training/training_handler.py
@@ -13,8 +13,14 @@ from src.training.general_utils import (
     setup_experiment_dirs,
     initialize_models,
     setup_loggers,
-    close_everything, ensure_tensor, )
-from src.training.training_loop_utils import init_training_results, prepare_models_for_cycle, perform_training_phase
+    close_everything,
+    ensure_tensor,
+)
+from src.training.training_loop_utils import (
+    init_training_results,
+    prepare_models_for_cycle,
+    perform_training_phase,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -24,7 +30,7 @@ logger = logging.getLogger(__name__)
 # Training Loop
 ##########################################
 
-def training_loop(experiment, env, agent_model, master_model):
+def training_loop(experiment, env, agent_model):
     """
     Main training loop that orchestrates cycles and episodes.
     """
@@ -59,14 +65,25 @@ def training_loop(experiment, env, agent_model, master_model):
 
     for cycle_num in range(1, experiment.CYCLES + 1):
         print('Cycle', cycle_num,'out of ', experiment.CYCLES)
-        train_both, training_master, training_agent = prepare_models_for_cycle(cycle_num, experiment.CYCLES,
-                                                                               master_model, agent_model)
+        train_both, training_master, training_agent = prepare_models_for_cycle(
+            cycle_num,
+            experiment.CYCLES,
+            None,
+            agent_model,
+        )
         for _ in range(experiment.EPISODES_PER_CYCLE):
 
             episode_counter += 1
             print('This is the ', episode_counter, 'Out of', experiment.EPISODES_PER_CYCLE * experiment.CYCLES, 'episodes')
-            episode_rewards, actions, steps, crashed = process_episode(episode_counter, total_steps, env, master_model,
-                                                              agent_model, experiment, train_both, training_master)
+            episode_rewards, actions, steps, crashed = process_episode(
+                episode_counter,
+                total_steps,
+                env,
+                agent_model,
+                experiment,
+                train_both,
+                training_master,
+            )
             if crashed:
                 collision_counter += 1
 
@@ -76,16 +93,23 @@ def training_loop(experiment, env, agent_model, master_model):
 
             # Prepare state for training
             with torch.no_grad():
-                _, _ = env.reset()
-                full_state = env.env.current_state
-                state_tensor = ensure_tensor(full_state)
+                last_obs, _ = env.reset()
+                state_tensor = ensure_tensor(last_obs)
 
             if episode_counter % experiment.EPISODE_AMOUNT_FOR_TRAIN == 0:
-                perform_training_phase(train_both, training_master, training_agent, master_model, agent_model, full_state,
-                                   state_tensor, results)
+                perform_training_phase(
+                    train_both,
+                    training_master,
+                    training_agent,
+                    None,
+                    agent_model,
+                    last_obs,
+                    state_tensor,
+                    results,
+                )
 
     print("Training completed.")
-    return agent_model, master_model, collision_counter, results["episode_rewards"], results["all_actions"], results
+    return agent_model, None, collision_counter, results["episode_rewards"], results["all_actions"], results
 
 #
 # def training_loop(experiment, env, agent_model, master_model):
@@ -167,10 +191,10 @@ def run_evaluation(experiment_config, env, agent_model):
 # Inference & Training Mode Handlers
 ##########################################
 
-def run_inference_mode(experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger):
+def run_inference_mode(experiment_config, wrapped_env, agent_model, agent_logger):
     """Run inference episodes only."""
     if experiment_config.LOAD_PREVIOUS_WEIGHT and experiment_config.LOAD_MODEL_DIRECTORY:
-        loaded = load_models(agent_model, master_model, experiment_config.LOAD_MODEL_DIRECTORY)
+        loaded = load_models(agent_model, None, experiment_config.LOAD_MODEL_DIRECTORY)
         if loaded:
             print("Models will be trained from loaded weights!")
         else:
@@ -179,21 +203,20 @@ def run_inference_mode(experiment_config, wrapped_env, agent_model, master_model
         print("Starting inference with untrained models (No previous weights loaded)")
 
     eval_rewards, eval_actions = run_evaluation(experiment_config, wrapped_env, agent_model)
-    close_everything(wrapped_env, agent_logger, master_logger)
-    return agent_model, master_model, 0
+    close_everything(wrapped_env, agent_logger)
+    return agent_model, None, 0
 
 
-def run_training_mode(experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger):
+def run_training_mode(experiment_config, wrapped_env, agent_model, agent_logger):
     """Run the training loop and handle saving/logging."""
-    agent_model, master_model, collision_counter, all_rewards, all_actions, training_results = (
-        training_loop(experiment=experiment_config, env=wrapped_env, agent_model=agent_model, master_model=master_model))
-    save_models(agent_model, master_model, experiment_config.SAVE_MODEL_DIRECTORY)
+    agent_model, _, collision_counter, all_rewards, all_actions, training_results = (
+        training_loop(experiment=experiment_config, env=wrapped_env, agent_model=agent_model))
+    save_models(agent_model, None, experiment_config.SAVE_MODEL_DIRECTORY)
     plot_training_results(experiment_config, training_results, show_plots=True)
     #log_training_results_to_neptune(experiment_config.logger, training_results)
     print("Training completed.")
     print("Total collisions:", collision_counter)
-    #close_everything(wrapped_env, agent_logger, master_logger)
-    return agent_model, master_model, collision_counter
+    return agent_model, None, collision_counter
 
 
 ##########################################
@@ -205,18 +228,23 @@ def run_experiment(experiment_config, env_config):
         f"Environment configuration: {len(env_config['controlled_cars'])} controlled cars, {len(env_config['static_cars'])} static cars"
     )
     setup_experiment_dirs(experiment_config.EXPERIMENT_PATH)
-    master_model, agent_model, wrapped_env = initialize_models(experiment_config, env_config)
-    agent_logger, master_logger = setup_loggers(experiment_config.EXPERIMENT_PATH)
+    agent_model, wrapped_env = initialize_models(experiment_config, env_config)
+    agent_logger = setup_loggers(experiment_config.EXPERIMENT_PATH)
     agent_model.set_logger(agent_logger)
-    master_model.set_logger(master_logger)
 
     if experiment_config.ONLY_INFERENCE:
         print("Running in inference-only mode")
         return run_inference_mode(
-            experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger
+            experiment_config,
+            wrapped_env,
+            agent_model,
+            agent_logger,
         )
     else:
         print("Running in training mode")
         return run_training_mode(
-            experiment_config, wrapped_env, agent_model, master_model, agent_logger, master_logger
+            experiment_config,
+            wrapped_env,
+            agent_model,
+            agent_logger,
         )

--- a/src/training/training_loop_utils.py
+++ b/src/training/training_loop_utils.py
@@ -11,18 +11,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def init_training_results() -> Dict[str, List[Any]]:
-    """
-    Initialize the structure for tracking training results.
-    """
+    """Initialize the structure for tracking training results."""
     return {
         "episode_rewards": [],
-        "master_policy_losses": [],
-        "master_value_losses": [],
-        "master_total_losses": [],
         "agent_policy_losses": [],
         "agent_value_losses": [],
         "agent_total_losses": [],
-        "all_actions": []
+        "all_actions": [],
     }
 
 
@@ -37,11 +32,15 @@ def prepare_models_for_cycle(
     Returns flags: (train_both, training_master, training_agent)
     """
     logger.info("Cycle %d/%d", cycle_num, total_cycles)
+
+    if master_model is None:
+        agent_model.policy.set_training_mode(True)
+        return False, False, True
+
     train_both = cycle_num == 1
     training_master = not train_both and (cycle_num % 2 == 0)
     training_agent = not train_both and (cycle_num % 2 == 1)
 
-    # Freeze/unfreeze master and set agent training mode
     if train_both or training_master:
         master_model.unfreeze()
     else:
@@ -91,8 +90,8 @@ def train_master_and_reset_buffer(master_model, full_obs):
 
 
 
-def train_agent_and_reset_buffer(master_model, agent_model, last_master_tensor):
-    """Trains the agent model and resets its buffer - Returns loss values"""
+def train_agent_and_reset_buffer(agent_model, last_observation_tensor):
+    """Train the agent model and reset buffers - returns loss values."""
     from src.project_globals import rollout_buffers
 
     for current_rollout_buffer in rollout_buffers:
@@ -100,23 +99,14 @@ def train_agent_and_reset_buffer(master_model, agent_model, last_master_tensor):
         policy_loss_val = value_loss_val = total_loss_val = None
         try:
             with torch.no_grad():
-                shaped_tensor = ensure_tensor(last_master_tensor)
-                embedding, _, _ = master_model.get_proto_action(shaped_tensor)
-                num_cars = len(agent_model.action_space.nvec)
-                master_state_np = np.array(last_master_tensor, dtype=np.float32).reshape(-1)
-                expected_state_size = num_cars * 4
-                if master_state_np.size < expected_state_size:
-                    padded_state = np.zeros(expected_state_size, dtype=np.float32)
-                    padded_state[: master_state_np.size] = master_state_np
-                    master_state_np = padded_state
-                elif master_state_np.size > expected_state_size:
-                    master_state_np = master_state_np[:expected_state_size]
-                car_states = master_state_np.reshape(num_cars, 4)
-                embedding_array = np.asarray(embedding, dtype=np.float32)
-                per_agent_obs = [np.concatenate((car_states[idx], embedding_array)) for idx in range(num_cars)]
-                agent_obs = np.stack(per_agent_obs, axis=0).astype(np.float32).reshape(-1)
-                agent_obs_tensor = torch.tensor(agent_obs, dtype=torch.float32).unsqueeze(0)
-                last_value = agent_model.policy.predict_values(agent_obs_tensor).detach().cpu().numpy().reshape(-1)
+                obs_tensor = ensure_tensor(last_observation_tensor)
+                last_value = (
+                    agent_model.policy.predict_values(obs_tensor)
+                    .detach()
+                    .cpu()
+                    .numpy()
+                    .reshape(-1)
+                )
 
             if current_rollout_buffer.pos == 0:
                 print("Agent model: No data to train on")
@@ -261,29 +251,22 @@ def perform_training_phase(
     training_agent: bool,
     master_model,
     agent_model,
-    full_state: Any,
+    last_observation: Any,
     state_tensor: torch.Tensor,
-    results: Dict[str, List[Any]]) -> None:
-    """
-    Execute training for master and/or agent and update results.
-    """
-    master_losses = None
-    agent_losses = None
-    if train_both or training_master:
-        master_losses = train_master_and_reset_buffer(master_model, full_state)
-    if train_both or training_agent:
-        agent_losses = train_agent_and_reset_buffer(master_model, agent_model, state_tensor)
+    results: Dict[str, List[Any]],
+) -> None:
+    """Execute training for the agent and update tracked losses."""
 
-    record_losses(
-        master_losses,
-        results["master_policy_losses"],
-        results["master_value_losses"],
-        results["master_total_losses"]
-    )
-    record_losses(
-        agent_losses,
-        results["agent_policy_losses"],
-        results["agent_value_losses"],
-        results["agent_total_losses"]
-    )
+    if master_model is not None and (train_both or training_master):
+        # Retain compatibility if a master model is provided in future experiments.
+        train_master_and_reset_buffer(master_model, last_observation)
+
+    if train_both or training_agent or master_model is None:
+        agent_losses = train_agent_and_reset_buffer(agent_model, state_tensor)
+        record_losses(
+            agent_losses,
+            results["agent_policy_losses"],
+            results["agent_value_losses"],
+            results["agent_total_losses"],
+        )
 


### PR DESCRIPTION
## Summary
- add an attention-based features extractor to the driver wrapper so the agent no longer depends on the master model
- rework model initialization and training loops to drop master usage and update logging utilities accordingly
- refresh plotting routines to focus on agent losses, including the new policy-loss curves

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e20ccd8c88332af6c2f5ce54b1155)